### PR TITLE
Reworked C++/Luna error handling

### DIFF
--- a/native_libs/src/Core/Error.cpp
+++ b/native_libs/src/Core/Error.cpp
@@ -1,11 +1,27 @@
 #include "Error.h"
 
+#include <iostream>
 #include <utility>
 
 namespace
 {
 	const auto unknownInternalErrorText = "Unknown internal error encountered";
 	thread_local std::string errorMessage;
+}
+
+void writeError(const char **outError, const char *toWrite)
+{
+	if(outError)
+	{
+		*outError = toWrite;
+	}
+	else if(toWrite)
+	{
+		// should not happen unless caller gives nullptr as error target
+		// in such case we will just write the error to stdout
+		// as we have no other means of getting user's attention
+		std::cout << "outError==nullptr, failed to set error message: " << toWrite << std::endl;
+	}
 }
 
 void setError(const char **outError, const char *errorToSet, const char *functionName) noexcept
@@ -17,17 +33,17 @@ void setError(const char **outError, const char *errorToSet, const char *functio
 		else
 			errorMessage = errorToSet;
 
-		*outError = errorMessage.c_str();
+		writeError(outError, errorMessage.c_str());
 	}
 	catch(...)
 	{
 		// should happen practically never, perhaps if error string is too long to fit in memory....
 		// but to be on the safe side
-		*outError = unknownInternalErrorText;
+		writeError(outError, unknownInternalErrorText);
 	}
 }
 
 void clearError(const char **outError) noexcept
 {
-	*outError = nullptr;
+	writeError(outError, nullptr);
 }

--- a/native_libs/src/Core/Error.cpp
+++ b/native_libs/src/Core/Error.cpp
@@ -8,11 +8,15 @@ namespace
 	thread_local std::string errorMessage;
 }
 
-void setError(const char **outError, const char *errorToSet) noexcept
+void setError(const char **outError, const char *errorToSet, const char *functionName) noexcept
 {
 	try
 	{
-		errorMessage = errorToSet;
+		if(functionName)
+			errorMessage = std::string(functionName) + ": " + errorToSet;
+		else
+			errorMessage = errorToSet;
+
 		*outError = errorMessage.c_str();
 	}
 	catch(...)

--- a/native_libs/src/Core/Error.h
+++ b/native_libs/src/Core/Error.h
@@ -1,11 +1,11 @@
 #pragma once
 #include <string>
 
-void setError(const char **outError, const char *errorToSet) noexcept;
+void setError(const char **outError, const char *errorToSet, const char *functionName) noexcept;
 void clearError(const char **outError) noexcept;
 
 template<typename Function>
-auto translateExceptionToError(const char **outError, Function &&f)
+auto translateExceptionToError(const char *functionName, const char **outError, Function &&f)
 {
 	try
 	{
@@ -14,11 +14,11 @@ auto translateExceptionToError(const char **outError, Function &&f)
 	}
 	catch(std::exception &e)
 	{
-		setError(outError, e.what());
+		setError(outError, e.what(), functionName);
 	}
 	catch(...)
 	{
-		setError(outError, "unknown exception");
+		setError(outError, "unknown exception", functionName);
 	}
 
 	using ResultType = decltype(f());
@@ -27,3 +27,28 @@ auto translateExceptionToError(const char **outError, Function &&f)
 	else
 		return;
 }
+
+struct ExceptionHelper 
+{
+	const char *functionName;
+	const char **outError;
+	
+	explicit ExceptionHelper(const char *functionName, const char **outError) 
+		: functionName(functionName), outError(outError)
+	{}
+
+	template<typename Function>
+	auto operator<<(Function &&f) const noexcept
+	{
+		return translateExceptionToError(functionName, outError, std::forward<Function>(f));
+	}
+};
+
+// Helper macro for translating between C++ exceptions and C API output error arguments.
+// Takes an OutError argument expected to be of type const char **.
+// Then takes a lambda body to be executed. All exceptions thrown from it will be catched
+// and translated to error messages that will be written to OutError.
+// If no exception is thrown, OutError shall be written with nullptr.
+// Macro yields a call that returns the value that nested body returns.
+// Body requires a semicolon after end. 
+#define TRANSLATE_EXCEPTION(OutError) ExceptionHelper(__FUNCTION__, OutError) << [&] () mutable

--- a/native_libs/src/Core/Matrix2d.cpp
+++ b/native_libs/src/Core/Matrix2d.cpp
@@ -1,8 +1,13 @@
 #include "Matrix2d.h"
+#include "Error.h"
 
 #include <algorithm>
+#include <iostream>
+#include <sstream>
 #include <unordered_map>
 #include <utility>
+
+using namespace std::literals;
 
 namespace
 {
@@ -13,16 +18,37 @@ namespace
 	// TODO: at some point in future thread-safety should be considered
 	// (either hide this map behind mutex or document safety requirements)
 	std::unordered_map<MatrixDataPtr, Matrix2d*> pointersToTheirManagers;
+
+	std::ostream &printIndex(std::ostream &out, size_t row, size_t column)
+	{
+		return out << "(" << row << ", " << column << ")";
+	}
+}
+
+void Matrix2d::verifyIndex(size_t row, size_t column) const
+{
+	const auto index = makeIndex(row, column);
+	if(index < 0 || index >= cellContents.size())
+	{
+		std::ostringstream errorMsg;
+		errorMsg << "Invalid index access: ";
+		printIndex(errorMsg, row, column);
+		errorMsg << ", matrix size is: ";
+		printIndex(errorMsg, rowCount, columnCount);
+		throw std::out_of_range(errorMsg.str());
+	}
 }
 
 std::string & Matrix2d::access(size_t row, size_t column)
 {
+	verifyIndex(row, column);
 	const auto index = makeIndex(row, column);
 	return cellContents.at(index);
 }
 
 void Matrix2d::fixPointer(size_t row, size_t column)
 {
+	verifyIndex(row, column);
 	const auto index = makeIndex(row, column);
 	const auto &value = cellContents.at(index);
 	items.at(index) = value.empty()
@@ -83,6 +109,7 @@ void Matrix2d::store(size_t row, size_t column, std::string contents)
 
 const std::string& Matrix2d::load(size_t row, size_t column) const
 {
+	verifyIndex(row, column);
 	const auto index = makeIndex(row, column);
 	return cellContents.at(index);
 }
@@ -94,7 +121,16 @@ MatrixDataPtr Matrix2d::data() const noexcept
 
 Matrix2d * Matrix2d::fromData(MatrixDataPtr data)
 {
-	return pointersToTheirManagers.at(data);
+	try
+	{
+		return pointersToTheirManagers.at(data);
+	}
+	catch(std::exception &e)
+	{
+		std::ostringstream errorMessage;
+		errorMessage << "failed to match data pointer " << data << " to a known Matrix2d object: " << e.what();
+		throw std::runtime_error(errorMessage.str());
+	}
 }
 
 
@@ -118,9 +154,9 @@ std::unique_ptr<Matrix2d> Matrix2d::copyRows(size_t rowCount, int *rowsToCopy) c
 	auto ret = std::make_unique<Matrix2d>(rowCount, columnCount);
 	for (auto row = 0ull; row < rowCount; row++)
 	{
+		const auto sourceRowIndex = rowsToCopy[row];
 		for (auto column = 0ull; column < columnCount; column++)
 		{
-			const auto sourceRowIndex = rowsToCopy[row];
 			auto value = load(sourceRowIndex, column);
 			ret->store(row, column, std::move(value));
 		}
@@ -170,129 +206,99 @@ std::unique_ptr<Matrix2d> Matrix2d::transpose() const
 
 extern "C" 
 {
+	// Note: as an exception, this function does not take ourError argument
+	// because ManagedPtr expects single argument function to call
 	void mat_delete(MatrixDataPtr mat) noexcept
 	{
 		try
 		{
 			delete Matrix2d::fromData(mat);
 		}
-		catch(...) {}
+		catch(...) 
+		{
+			// Note: generally we don't want this library to print anything
+			// but this should really not happen and we have no other means
+			// of thelling the world that something went wrong.
+			std::cout << __FUNCTION__ << ": " << "error" << std::endl;
+		}
 	}
-	MatrixDataPtr allocate(size_t rowCount, size_t columnCount) noexcept
+	MatrixDataPtr allocate(size_t rowCount, size_t columnCount, const char **outError) noexcept
 	{
-		try
+		return TRANSLATE_EXCEPTION(outError)
 		{
 			return std::make_unique<Matrix2d>(rowCount, columnCount).release()->data();
-		}
-		catch(...) 
-		{
-			return nullptr;
-		}
+		};
 	}
 
-	MatrixDataPtr copyColumns(MatrixDataPtr mat, size_t columnCount, int *columnsToCopy) noexcept
+	MatrixDataPtr copyColumns(MatrixDataPtr mat, size_t columnCount, int *columnsToCopy, const char **outError) noexcept
 	{
-		try
+		return TRANSLATE_EXCEPTION(outError)
 		{
 			return Matrix2d::fromData(mat)->copyColumns(columnCount, columnsToCopy).release()->data();
-		}
-		catch(...) 
-		{
-			return nullptr;
-		}
+		};
 	}
 
-	MatrixDataPtr copyRows(MatrixDataPtr mat, size_t rowCount, int *rowsToCopy) noexcept
+	MatrixDataPtr copyRows(MatrixDataPtr mat, size_t rowCount, int *rowsToCopy, const char **outError) noexcept
 	{
-		try
+		return TRANSLATE_EXCEPTION(outError)
 		{
 			return Matrix2d::fromData(mat)->copyRows(rowCount, rowsToCopy).release()->data();
-		}
-		catch(...)
-		{
-			return nullptr;
-		}
+		};
 	}
 
-	MatrixDataPtr dropRow(MatrixDataPtr mat, int rowToDrop) noexcept
+	MatrixDataPtr dropRow(MatrixDataPtr mat, int rowToDrop, const char **outError) noexcept
 	{
-		try
+		return TRANSLATE_EXCEPTION(outError)
 		{
 			return Matrix2d::fromData(mat)->dropRow(rowToDrop).release()->data();
-		}
-		catch(...)
-		{
-			return nullptr;
-		}
+		};
 	}
 	
-	MatrixDataPtr transpose(MatrixDataPtr mat) noexcept
+	MatrixDataPtr transpose(MatrixDataPtr mat, const char **outError) noexcept
 	{
-		try
+		return TRANSLATE_EXCEPTION(outError)
 		{
 			return Matrix2d::fromData(mat)->transpose().release()->data();
-		}
-		catch(...)
-		{
-			return nullptr;
-		}
+		};
 	}
 
-	void store(MatrixDataPtr mat, size_t row, size_t column, const char *string) noexcept
+	void store(MatrixDataPtr mat, size_t row, size_t column, const char *string, const char **outError) noexcept
 	{
-		try
+		return TRANSLATE_EXCEPTION(outError)
 		{
 			return Matrix2d::fromData(mat)->store(row, column, string);
-		}
-		catch(...) 
-		{}
+		};
 	}
 
-	MatrixDataPtr mat_clone(MatrixDataPtr mat) noexcept
+	MatrixDataPtr mat_clone(MatrixDataPtr mat, const char **outError) noexcept
 	{
-		try
+		return TRANSLATE_EXCEPTION(outError)
 		{
 			return std::make_unique<Matrix2d>(*Matrix2d::fromData(mat)).release()->data();
-		}
-		catch(...) 
-		{
-			return nullptr;
-		}
+		};
 	}
 
-	MatrixDataPtr join(MatrixDataPtr top, MatrixDataPtr bottom) noexcept
+	MatrixDataPtr join(MatrixDataPtr top, MatrixDataPtr bottom, const char **outError) noexcept
 	{
-		try
+		return TRANSLATE_EXCEPTION(outError)
 		{
 			return std::make_unique<Matrix2d>(*Matrix2d::fromData(top), *Matrix2d::fromData(bottom)).release()->data();
-		}
-		catch(...) 
-		{
-			return nullptr;
-		}
+		};
 	}
 
-	size_t columnCount(MatrixDataPtr mat) noexcept
+	size_t columnCount(MatrixDataPtr mat, const char **outError) noexcept
 	{
-		try
+		return TRANSLATE_EXCEPTION(outError)
 		{
 			return Matrix2d::fromData(mat)->columnCount;
-		}
-		catch(...)
-		{
-			return 0;
-		}
+		};
 	}
 
-	size_t rowCount(MatrixDataPtr mat) noexcept
+	size_t rowCount(MatrixDataPtr mat, const char **outError) noexcept
 	{
-		try
+		return TRANSLATE_EXCEPTION(outError)
 		{
 			return Matrix2d::fromData(mat)->rowCount;
-		}
-		catch(...)
-		{
-			return 0;
-		}
+		};
 	}
 }

--- a/native_libs/src/Core/Matrix2d.h
+++ b/native_libs/src/Core/Matrix2d.h
@@ -15,6 +15,7 @@ class Matrix2d
 	std::vector<std::string> cellContents; // manages memory for cell contents
 	std::vector<const char *> items; // exposes strings as Luna-consumable array of C-style strings
 
+	void verifyIndex(size_t row, size_t column) const;
 	std::string &access(size_t row, size_t column);
 	void fixPointer(size_t row, size_t column);
 
@@ -58,15 +59,15 @@ public:
 
 extern "C"
 {
-	EXPORT MatrixDataPtr mat_clone(MatrixDataPtr mat) noexcept;
+	EXPORT MatrixDataPtr mat_clone(MatrixDataPtr mat, const char **outError) noexcept;
 	EXPORT void mat_delete(MatrixDataPtr mat) noexcept;
-	EXPORT MatrixDataPtr allocate(size_t rowCount, size_t columnCount) noexcept;
-	EXPORT size_t columnCount(MatrixDataPtr mat) noexcept;
-	EXPORT size_t rowCount(MatrixDataPtr mat) noexcept;
-	EXPORT MatrixDataPtr join(MatrixDataPtr top, MatrixDataPtr bottom) noexcept;
-	EXPORT MatrixDataPtr copyColumns(MatrixDataPtr mat, size_t columnCount, int *columnsToCopy) noexcept;
-	EXPORT MatrixDataPtr copyRows(MatrixDataPtr mat, size_t rowCount, int *rowsToCopy) noexcept;
-	EXPORT MatrixDataPtr dropRow(MatrixDataPtr mat, int rowToDrop) noexcept;
-	EXPORT MatrixDataPtr transpose(MatrixDataPtr mat) noexcept;
-	EXPORT void store(MatrixDataPtr mat, size_t row, size_t column, const char *string) noexcept;
+	EXPORT MatrixDataPtr allocate(size_t rowCount, size_t columnCount, const char **outError) noexcept;
+	EXPORT size_t columnCount(MatrixDataPtr mat, const char **outError) noexcept;
+	EXPORT size_t rowCount(MatrixDataPtr mat, const char **outError) noexcept;
+	EXPORT MatrixDataPtr join(MatrixDataPtr top, MatrixDataPtr bottom, const char **outError) noexcept;
+	EXPORT MatrixDataPtr copyColumns(MatrixDataPtr mat, size_t columnCount, int *columnsToCopy, const char **outError) noexcept;
+	EXPORT MatrixDataPtr copyRows(MatrixDataPtr mat, size_t rowCount, int *rowsToCopy, const char **outError) noexcept;
+	EXPORT MatrixDataPtr dropRow(MatrixDataPtr mat, int rowToDrop, const char **outError) noexcept;
+	EXPORT MatrixDataPtr transpose(MatrixDataPtr mat, const char **outError) noexcept;
+	EXPORT void store(MatrixDataPtr mat, size_t row, size_t column, const char *string, const char **outError) noexcept;
 }

--- a/native_libs/src/Core/Utils.cpp
+++ b/native_libs/src/Core/Utils.cpp
@@ -7,7 +7,7 @@
 extern "C"
 {
 
-EXPORT double luna_to_double(char *data)
+EXPORT double luna_to_double(char *data, const char **error)
 {
     double d;
     std::sscanf(data,"%lf", &d);

--- a/native_libs/src/IO/xlsx.cpp
+++ b/native_libs/src/IO/xlsx.cpp
@@ -12,20 +12,20 @@ extern "C"
 {
 	// Provide stub methods that just report error.
 
-	EXPORT MatrixDataPtr read_xlsx(const char *filename, const char **error) noexcept
+	EXPORT MatrixDataPtr read_xlsx(const char *filename, const char **outError) noexcept
 	{
-		return translateExceptionToError(error, [&] () -> MatrixDataPtr
+		return TRANSLATE_EXCEPTION(outError) -> MatrixDataPtr
 		{
 			throw std::runtime_error("The library was compiled without XLSX support!");
-		});
+		};
 	}
 
-	EXPORT void write_xlsx(MatrixDataPtr mat, const char *filename, const char **error) noexcept
+	EXPORT void write_xlsx(MatrixDataPtr mat, const char *filename, const char **outError) noexcept
 	{
-		return translateExceptionToError(error, [&]
+		return TRANSLATE_EXCEPTION(outError)
 		{
 			throw std::runtime_error("The library was compiled without XLSX support!");
-		});
+		};
 	}
 }
 
@@ -90,21 +90,21 @@ namespace
 
 extern "C"
 {
-	EXPORT MatrixDataPtr read_xlsx(const char *filename, const char **error) noexcept
+	EXPORT MatrixDataPtr read_xlsx(const char *filename, const char **outError) noexcept
 	{
-		return translateExceptionToError(error, [&] 
+		return TRANSLATE_EXCEPTION(outError)
 		{
 			auto mat = xlsxParseFile(filename);
 			return mat.release()->data();
-		});
+		};
 	}
 
-	EXPORT void write_xlsx(MatrixDataPtr mat, const char *filename, const char **error) noexcept
+	EXPORT void write_xlsx(MatrixDataPtr mat, const char *filename, const char **outError) noexcept
 	{
-		translateExceptionToError(error, [&] 
+		return TRANSLATE_EXCEPTION(outError)
 		{
 			xlsxPrintToFile(*Matrix2d::fromData(mat), filename); 
-		});
+		};
 	}
 }
 

--- a/src/Array2D.luna
+++ b/src/Array2D.luna
@@ -29,9 +29,6 @@ class Array2D a:
     def cppSym name:
         lookupSymbol "DataframeHelper" name
 
-    def cppCall name ret args:
-        self.cppSym name . call ret args
-
     def getPtr: case self of
         Array2DVal _ _ _ p: p
 
@@ -127,7 +124,7 @@ class Array2D a:
                     True: ""
 
     def clone:
-        newMat = self.cppCall "mat_clone" (Pointer CString) [self.getPtr . toCArg]
+        newMat = cCallHandlingError "mat_clone" (Pointer CString) [self.getPtr . toCArg]
         newMatManaged = ManagedPointer CString . fromPointer (self.cppSym "mat_delete") newMat
         newMatManaged
 
@@ -137,7 +134,7 @@ class Array2D a:
         strideR = self.getStride.strideR
         strideC = self.getStride.strideC
 
-        newMat = self.cppCall "dropRow" (Pointer CString) [self.getPtr . toCArg, CInt.fromInt n . toCArg]
+        newMat = cCallHandlingError "dropRow" (Pointer CString) [self.getPtr . toCArg, CInt.fromInt n . toCArg]
         matManaged = ManagedPointer CString . fromPointer (self.cppSym "mat_delete") newMat
         Array2DVal (SizeVal rows-1 cols) self.getStride 0 matManaged
 
@@ -145,7 +142,7 @@ class Array2D a:
         row = indexN.head.get 
         column = indexN.getAt 1
         textC = CString.fromText text
-        self.cppCall "store" None [self.getPtr . toCArg, CInt.fromInt column . toCArg, CInt.fromInt row . toCArg, textC.toCArg]
+        cCallHandlingError "store" None [self.getPtr . toCArg, CInt.fromInt column . toCArg, CInt.fromInt row . toCArg, textC.toCArg]
         textC.free
     
     # Takes element by index, interprests as `ft` type, passes through the function and returns result
@@ -217,7 +214,7 @@ class Array2D a:
         strideR = self.getStride.strideR
         strideC = self.getStride.strideC
         columnsArray = Array CInt . fromList (listOfColumns . map CInt.fromInt)
-        newMat = self.cppCall "copyColumns" (Pointer CString) [self.getPtr . toCArg, CInt.fromInt l . toCArg, columnsArray.ptr . toCArg]
+        newMat = cCallHandlingError "copyColumns" (Pointer CString) [self.getPtr . toCArg, CInt.fromInt l . toCArg, columnsArray.ptr . toCArg]
         matManaged = ManagedPointer CString . fromPointer (self.cppSym "mat_delete") newMat
         Array2DVal (SizeVal rows l) (StrideVal l strideC) 0 matManaged
 
@@ -228,7 +225,7 @@ class Array2D a:
         strideR = self.getStride.strideR
         strideC = self.getStride.strideC
         rowsArray = Array CInt . fromList (listOfRows . map CInt.fromInt)
-        newMat = self.cppCall "copyRows" (Pointer CString) [self.getPtr . toCArg, CInt.fromInt l . toCArg, rowsArray.ptr . toCArg]
+        newMat = cCallHandlingError "copyRows" (Pointer CString) [self.getPtr . toCArg, CInt.fromInt l . toCArg, rowsArray.ptr . toCArg]
         matManaged = ManagedPointer CString . fromPointer (self.cppSym "mat_delete") newMat
         Array2DVal (SizeVal l cols) self.getStride 0 matManaged
 
@@ -237,7 +234,7 @@ class Array2D a:
         cols = self.getSize.columns
         strideR = self.getStride.strideR
         strideC = self.getStride.strideC
-        newMat = self.cppCall "transpose" (Pointer CString) [self.getPtr . toCArg]
+        newMat = cCallHandlingError "transpose" (Pointer CString) [self.getPtr . toCArg]
         matManaged = ManagedPointer CString . fromPointer (self.cppSym "mat_delete") newMat
         Array2DVal (SizeVal cols rows) (StrideVal rows 1) 0 matManaged
 
@@ -246,6 +243,6 @@ class Array2D a:
         fstCols = self.getSize.columns
         sndRows = arrayToJoin.getSize.rows
         sndCols = arrayToJoin.getSize.columns
-        newMat = self.cppCall "join" (Pointer CString) [self.getPtr . toCArg, arrayToJoin.getPtr . toCArg]
+        newMat = cCallHandlingError "join" (Pointer CString) [self.getPtr . toCArg, arrayToJoin.getPtr . toCArg]
         matManaged = ManagedPointer CString . fromPointer (self.cppSym "mat_delete") newMat
         Array2DVal (SizeVal fstRows+sndRows fstCols) (StrideVal fstCols 1) 0 matManaged

--- a/src/Dataframes.luna
+++ b/src/Dataframes.luna
@@ -14,12 +14,6 @@ class Dataframe:
     def cSym name:
         lookupSymbol "DataframeHelper" name
 
-    def cStdSym name:
-        lookupSymbol cStdLib name
-
-    def cCall name ret args:
-        self . cSym name . call ret args
-
     def header: case self of
         DataframeVal h _ _: h
     
@@ -33,15 +27,11 @@ class Dataframe:
         DataframeVal _ _ d: d
 
     def readFromCSV file readHeader:
-        rows = ManagedPointer CInt . malloc
-        cols = ManagedPointer CInt . malloc
-        err  = ManagedPointer CInt . malloc
-        mat  = self.cCall "read_csv" (Pointer CString) [CString.fromText file . toCArg, rows.toCArg, cols.toCArg, err.toCArg]
-        matManaged = case err.read.toInt of
-            0: ManagedPointer CString . fromPointer (self.cSym "mat_delete") mat
-            _: throw err.read.toText
-        r = rows.read.toInt
-        c = cols.read.toInt
+        commaSeparator = CChar.fromInt 44
+        mat = cCallHandlingError "read_csv" (Pointer CString) [CString.fromText file . toCArg, commaSeparator.toCArg]
+        matManaged = ManagedPointer CString . fromPointer (self.cSym "mat_delete") mat
+        r = rowCount matManaged
+        c = columnCount matManaged
         type = 0 . upto c . each (k: FieldReal)
         case readHeader of
             True:
@@ -53,26 +43,17 @@ class Dataframe:
                 DataframeVal Nothing type ((Array2DVal (SizeVal r c) (StrideVal c 1) 0 matManaged) . cTranspose)
 
     def writeToCSV filename:
+        commaSeparator = CChar.fromInt 44
         withHeader = case self.header of
             Nothing: self.data.cTranspose
             Just h :
-                    
-                    dataT = self.data.cTranspose
-                    h.join dataT
-        rows = withHeader.getSize.rows
-        cols = withHeader.getSize.columns
-        err = ManagedPointer CInt . malloc
-        self.cCall "write_csv" None [CString.fromText filename . toCArg, withHeader.getPtr . toCArg, CInt.fromInt rows . toCArg, CInt.fromInt cols . toCArg, err.toCArg]
-        case err.read.toInt of
-            0: None
-            _: throw err.read.toText
+                dataT = self.data.cTranspose
+                h.join dataT
+        cCallHandlingError "write_csv" None [CString.fromText filename . toCArg, withHeader.getPtr . toCArg, commaSeparator.toCArg]
 
     def readFromXlsx file readHeader:
-        err  = ManagedPointer CString . malloc
-        mat  = self.cCall "read_xlsx" (Pointer CString) [CString.fromText file . toCArg, err.toCArg]
-        matManaged = case err.read.isNull of
-            True: ManagedPointer CString . fromPointer (self.cSym "mat_delete") mat
-            False: throw (err.read.toText)
+        mat = cCallHandlingError "read_xlsx" (Pointer CString) [CString.fromText file . toCArg]
+        matManaged = ManagedPointer CString . fromPointer (self.cSym "mat_delete") mat
         r = rowCount matManaged
         c = columnCount matManaged
         type = 0 . upto c . each (k: FieldReal)

--- a/src/Main.luna
+++ b/src/Main.luna
@@ -6,12 +6,12 @@ import Dataframes.Array2D
 
 
 
-«1»def f x:
-    «4»case x of
+def f x:
+    case x of
         ValueReal r: r*0.776
         ValueText t: throw "invalid type"
 
-«2»def main:
+def main:
     filename = "./data/simple_empty.csv"
     csv = Dataframe.readFromCSV filename True
     column = csv.selectColumns [0,2]

--- a/src/Utils.luna
+++ b/src/Utils.luna
@@ -1,6 +1,18 @@
 import Std.Foreign.C.Value
 import Std.Foreign
 
+def cCallHandlingError fname ret args:
+    err  = Pointer CString . malloc
+    result = lookupSymbol "DataframeHelper" fname . call ret (args + [err.toCArg])
+    case err.read.isNull of
+        True:
+            err.free
+            result
+        False:
+            errorMsg = err.read.toText
+            err.free
+            throw errorMsg
+
 def parseTextToDouble x:
     cString = CString.fromText x
     double = lookupSymbol "DataframeHelper" "luna_to_double" . call CDouble [cString . toCArg]
@@ -8,9 +20,9 @@ def parseTextToDouble x:
     double.toReal
 
 def rowCount ptr: 
-    rows = lookupSymbol "DataframeHelper" "rowCount" . call CInt [ptr . toCArg]
+    rows = cCallHandlingError "rowCount" CInt [ptr . toCArg]
     rows.toInt
 
 def columnCount ptr: 
-    columns = lookupSymbol "DataframeHelper" "columnCount" . call CInt [ptr . toCArg]
+    columns = cCallHandlingError "columnCount" CInt [ptr . toCArg]
     columns.toInt


### PR DESCRIPTION
This PR introduces unified mechanism for error handling on the boundary of C++/C/Luna. The goals are:
* to prevent crashes when Luna methods are called with invalid arguments;
* to provide better diagnostics to the user when something goes wrong;
* to unify way of reporting errors between various methods, so reporting/handling code can be easily reused — so having more robust code won't necessarily mean having to write more code.

Changes are twofold:
1. The C++ helper library C API functions all received a final parameter of type `const char **` for error reporting. On success, the `nullptr` is stored to the argument "pointee pointer". On failure, the "pointee pointer" is set to an error message.
   * Error message memory is managed by the C++ library and is guaranteed to be kept at least until the next C API call. The error message is thread-local. That allows multiple threads to make calls to the library without risk of overwriting each other's error messages.
   * C++ library got a helper macro `TRANSLATE_EXCEPTION` that calls given code block while translating all exceptions.
   * C++ library got some additional checks and error pretty printing for better diagnostics (e.g. giving invalid index value and matrix sizes on an out-of-bounds access).
2. All Luna code for error handling has been implemented in the `cCallHandlingError` function in the `Utils` module. It checks the result of the call and either passes the result to the caller or, in case of failure, raises a Luna exception with the error message obtained from the callee.

While changing virtually all C API function signatures, I have also made a few minor adjustments:
* removed some unnecessary arguments (passing the sizes, when they are known or can be obtained in other way);
* allowed passing the separator character from Luna in CSV read/write.

