### PR TITLE
Fix for #46 by changing the formula

### DIFF
--- a/native_libs/src/Analysis.h
+++ b/native_libs/src/Analysis.h
@@ -15,6 +15,7 @@ DFH_EXPORT std::shared_ptr<arrow::Column> calculateMax(const arrow::Column &colu
 DFH_EXPORT std::shared_ptr<arrow::Column> calculateMean(const arrow::Column &column);
 DFH_EXPORT std::shared_ptr<arrow::Column> calculateMedian(const arrow::Column &column);
 DFH_EXPORT std::shared_ptr<arrow::Column> calculateVariance(const arrow::Column &column);
+DFH_EXPORT std::shared_ptr<arrow::Column> calculateRSI(const arrow::Column &column);
 DFH_EXPORT std::shared_ptr<arrow::Column> calculateStandardDeviation(const arrow::Column &column);
 DFH_EXPORT std::shared_ptr<arrow::Column> calculateSum(const arrow::Column &column);
 DFH_EXPORT std::shared_ptr<arrow::Column> calculateQuantile(const arrow::Column &column, double q);

--- a/native_libs/test/Tests.cpp
+++ b/native_libs/test/Tests.cpp
@@ -909,6 +909,30 @@ BOOST_AUTO_TEST_CASE(Statistics)
 // 	calculateCorrelation(*toColumn(a), *toColumn(b));
 }
 
+struct RsiTestingFixture
+{
+    auto rsi(const std::vector<std::optional<double>> &vector)
+    {
+        auto col = toColumn(vector);
+        auto resultCol = calculateRSI(*col);
+        return toVector<std::optional<double>>(*resultCol);
+    }
+
+    auto test(const std::vector<std::optional<double>> &input, const std::vector<std::optional<double>> &expectedOutput)
+    {
+        auto actualOutput = rsi(input);
+        BOOST_CHECK_EQUAL_RANGES(expectedOutput, actualOutput);
+    }
+};
+
+BOOST_FIXTURE_TEST_CASE(RSI, RsiTestingFixture)
+{
+    test({ 5.0, 10.0, 6.0    }, { 100.0        });
+    test({ -5.0, -10.0, -6.0 }, { 0.0          });
+    test({                   }, { std::nullopt });
+    test({ std::nullopt      }, { std::nullopt });
+}
+
 template<typename T>
 void testInterpolation(std::vector<std::optional<T>> input, std::vector<std::optional<T>> expectedOutput)
 {


### PR DESCRIPTION
This PR corrects the RSI formula, fixing wrong results that resulted (but was not limited to) in #46.
Also, calculating RSI has been exposed from Analytics module, to allow for automatic tests for corner cases.

As written in #46:
> The behavior comes from the Python code given as implementation sample in #36. By comparing with [Wikipedia article](https://en.wikipedia.org/wiki/Relative_strength_index) it seems that samples with price decrease should count as 0 increase as well (and price increase should count as 0 decrease) for the purpose of mean increase calculation.
The Python code doesn't do that and samples consisting only of price growths yields nan instead of 100. I going to fix this, but this will change the behavior from specified.