### PR TITLE
Building Table from columns varying in length

### DIFF
--- a/native_libs/src/Core/Common.h
+++ b/native_libs/src/Core/Common.h
@@ -185,3 +185,14 @@ using is_detected = typename detail::is_detected<Trait, void, Args...>::type;
 
 template <template <class...> class Trait, class... Args>
 constexpr bool is_detected_v = is_detected<Trait, Args...>::value;
+
+template<typename Range, typename Functor, typename Value>
+Value maxElementValue(Range &&range, Value forEmptyRange, Functor &&f)
+{
+    if(std::empty(range))
+        return forEmptyRange;
+
+    auto minItr = std::max_element(std::begin(range), std::end(range), [&] (auto &&lhs, auto &&rhs) 
+        { return f(lhs) < f(rhs); });
+    return f(*minItr);
+}

--- a/native_libs/test/Tests.cpp
+++ b/native_libs/test/Tests.cpp
@@ -1003,6 +1003,23 @@ BOOST_AUTO_TEST_CASE(AutoCorrelation)
     // Note: values above are calculated by pandas.
 }
 
+BOOST_AUTO_TEST_CASE(TableFromColumnsWithVaryingLengths)
+{
+    std::vector<int64_t> ints = { 1, 2, 3 };
+    std::vector<std::optional<double>> doubles = {1.0, 2.0, std::nullopt, 4.0};
+
+    auto table = tableFromColumns({toColumn(ints), toColumn(doubles)});
+    BOOST_CHECK_EQUAL(table->num_rows(), 4);
+    for(auto col : getColumns(*table))
+        BOOST_CHECK_EQUAL(col->length(), table->num_rows());
+
+    auto [ints2, doubles2] = toVectors<std::optional<int64_t>, std::optional<double>>(*table);
+    std::vector<std::optional<int64_t>> expectedInts2{ 1, 2, 3, std::nullopt };
+    std::vector<std::optional<double>> expectedDoubles2{ 1.0, 2.0, std::nullopt, 4.0 };
+    BOOST_CHECK_EQUAL_RANGES(ints2, expectedInts2);
+    BOOST_CHECK_EQUAL_RANGES(doubles2, expectedDoubles2);
+}
+
 BOOST_AUTO_TEST_CASE(Rolling, *boost::unit_test_framework::disabled())
 {
     const date::sys_days day = 2013_y / jan / 01;


### PR DESCRIPTION
Previously passing such columns would create broken Table that could cause serious issues on attempted usage. With this change columns will be padded with nulls, so they all have the same length. Fixes #62.