### PR TITLE
Deducing file format when reading table + IO refactor

### DIFF
--- a/native_libs/src/Core/Utils.cpp
+++ b/native_libs/src/Core/Utils.cpp
@@ -152,7 +152,7 @@ void uglyPrint(const arrow::Table &table, std::ostream &out, int rows /*= 20*/)
 
     int64_t partsSize = rows / 2;
 
-    for(int64_t row = 0; row < partsSize && row <= partsSize && row < (int64_t)cells.size(); row++)
+    for(int64_t row = 0; row < partsSize && row < (int64_t)cells.size(); row++)
         printRow(row);
 
     auto skippedRows = table.num_rows() - partsSize * 2;

--- a/native_libs/src/Core/Utils.cpp
+++ b/native_libs/src/Core/Utils.cpp
@@ -149,12 +149,15 @@ void uglyPrint(const arrow::Table &table, std::ostream &out, int rows /*= 20*/)
         out << std::endl;
     };
 
+
     int64_t partsSize = rows / 2;
 
-    for(int64_t row = 0; row < partsSize && row <= partsSize; row++)
+    for(int64_t row = 0; row < partsSize && row <= partsSize && row < (int64_t)cells.size(); row++)
         printRow(row);
 
-    out << "... " << (table.num_rows() - partsSize * 2) << " more rows ...\n";
+    auto skippedRows = table.num_rows() - partsSize * 2;
+    if(skippedRows > 0)
+        out << "... " << skippedRows << " more rows ...\n";
 
     for(int64_t row = partsSize + 1; row < (int64_t)cells.size(); row++)
         printRow(row);

--- a/native_libs/src/IO/Feather.h
+++ b/native_libs/src/IO/Feather.h
@@ -4,11 +4,16 @@
 #include <string>
 
 #include "Core/Common.h"
+#include "IO.h"
 
 namespace arrow
 {
     class Table;
 }
 
-DFH_EXPORT void saveTableToFeatherFile(const std::string &filepath, const arrow::Table &table);
-DFH_EXPORT std::shared_ptr<arrow::Table> loadTableFromFeatherFile(const std::string &filepath);
+struct DFH_EXPORT FormatFeather : TableFileHandler
+{
+    virtual std::string fileSignature() const override;
+    virtual std::shared_ptr<arrow::Table> read(std::string_view filePath) const override;
+    virtual void write(std::string_view filePath, const arrow::Table &table) const override;
+};

--- a/native_libs/src/IO/XLSX.cpp
+++ b/native_libs/src/IO/XLSX.cpp
@@ -194,7 +194,7 @@ namespace
                     auto ymd = year_month_day(daypoint);   // calendar date
                     time_of_day tod = make_time(field - daypoint); // Yields time_of_day type
 
-                                                                   // Obtain individual components as integers
+                    // Obtain individual components as integers
                     auto y = (int)ymd.year();
                     auto m = (int)(unsigned)ymd.month();
                     auto d = (int)(unsigned)ymd.day();
@@ -203,7 +203,7 @@ namespace
                     auto s = (int)tod.seconds().count();
                     auto us = (int)std::chrono::duration_cast<std::chrono::microseconds>(tod.subseconds()).count();
 
-                    xlnt::datetime timestamp{ y, m, d, h, min, s, us }; // TODO: microsecond
+                    xlnt::datetime timestamp{ y, m, d, h, min, s, us };
                     cell.value(timestamp);
                 }
                 else

--- a/native_libs/src/IO/XLSX.cpp
+++ b/native_libs/src/IO/XLSX.cpp
@@ -14,14 +14,16 @@
 
 #pragma message("Note: DataframeHelper is being compiled without XLSX support.")  
 
-
-std::shared_ptr<arrow::Table> readXlsxFile(const char *filepath, HeaderPolicy header, std::vector<ColumnType> columnTypes)
+namespace
 {
-    throw std::runtime_error("The library was compiled without XLSX support!");
-}
-void writeXlsx(std::ostream &out, const arrow::Table &table, GeneratorHeaderPolicy headerPolicy)
-{
-    throw std::runtime_error("The library was compiled without XLSX support!");
+    std::shared_ptr<arrow::Table> readXlsxFile(const char *filepath, HeaderPolicy header, std::vector<ColumnType> columnTypes)
+    {
+        throw std::runtime_error("The library was compiled without XLSX support!");
+    }
+    void writeXlsx(std::ostream &out, const arrow::Table &table, GeneratorHeaderPolicy headerPolicy)
+    {
+        throw std::runtime_error("The library was compiled without XLSX support!");
+    }
 }
 
 #else // DISABLE_XLSX
@@ -94,136 +96,157 @@ namespace
             return ::finish(*builder);
         }
     };
-}
 
-std::shared_ptr<arrow::Table> readXlsxFile(const char *filepath, HeaderPolicy header, std::vector<ColumnType> columnTypes)
-{
-    try
+    std::shared_ptr<arrow::Table> readXlsxInput(std::istream &input, HeaderPolicy header, std::vector<ColumnType> columnTypes)
+    {
+        try
+        {
+            xlnt::workbook wb;
+            wb.load(input);
+            const auto sheet = wb.active_sheet();
+
+            // We keep the object under unique_ptr, so there will be
+            // no leak if exception is thrown before the end of function
+            const auto rowCount = (int64_t)sheet.highest_row();
+            const auto columnCount = (int32_t)sheet.highest_column().index;
+
+            // If there is no type info for column, default to non-nullable Text (it always works)
+            if((int)columnTypes.size() < columnCount)
+            {
+                const ColumnType nonNullableText{ std::make_shared<arrow::StringType>(), false, false };
+                columnTypes.resize(columnCount, nonNullableText);
+            }
+            const auto names = decideColumnNames(columnCount, header, [&](int column)
+            {
+                return sheet.cell(column + 1, 0 + 1).to_string();
+            });
+            const bool useFirstRowAsHeaders = std::holds_alternative<TakeFirstRowAsHeaders>(header);
+
+            // setup column builders
+            std::vector<std::unique_ptr<ColumnBuilderBase>> columnBuilders;
+            for(auto columnType : columnTypes)
+            {
+                auto ptr = visitType(*columnType.type, [&](auto id) -> std::unique_ptr<ColumnBuilderBase>
+                {
+                    return std::make_unique<ColumnBuilder<id.value>>(columnType.nullable);
+                });
+                ptr->reserve(rowCount);
+                columnBuilders.push_back(std::move(ptr));
+            }
+            for(auto i = columnBuilders.size(); i < columnCount; i++)
+            {
+                columnBuilders.push_back(std::make_unique<ColumnBuilder<arrow::Type::STRING>>(false));
+            }
+
+            for(int column = 0; column < columnCount; column++)
+            {
+                for(int row = useFirstRowAsHeaders; row < rowCount; row++)
+                {
+                    xlnt::cell_reference cellPos(column + 1, row + 1);
+                    if(sheet.has_cell(cellPos))
+                        columnBuilders[column]->addFromCell(sheet.cell(cellPos));
+                    else
+                        columnBuilders[column]->addMissing();
+                }
+            }
+
+            std::vector<std::shared_ptr<arrow::Array>> arrays;
+            for(auto &builder : columnBuilders)
+                arrays.push_back(builder->finish());
+
+
+            return buildTable(names, arrays, columnTypes);
+
+        }
+        catch(std::exception &e)
+        {
+            THROW("failed to load XLSX: {}", e.what());
+        }
+    }
+
+    void writeXlsx(std::ostream &out, const arrow::Table &table, GeneratorHeaderPolicy headerPolicy)
     {
         xlnt::workbook wb;
-        wb.load(filepath);
-        const auto sheet = wb.active_sheet();
+        auto sheet = wb.active_sheet();
+        sheet.title("Table");
 
-        // We keep the object under unique_ptr, so there will be
-        // no leak if exception is thrown before the end of function
-        const auto rowCount    = (int64_t)sheet.highest_row();
-        const auto columnCount = (int32_t)sheet.highest_column().index;
+        if(headerPolicy == GeneratorHeaderPolicy::GenerateHeaderLine)
+            for(int column = 0; column < table.num_columns(); column++)
+                sheet.cell(column + 1, 1).value(table.column(column)->name());
 
-        // If there is no type info for column, default to non-nullable Text (it always works)
-        if((int)columnTypes.size() < columnCount)
-        {
-            const ColumnType nonNullableText{ std::make_shared<arrow::StringType>(), false, false };
-            columnTypes.resize(columnCount, nonNullableText);
-        }
-        const auto names = decideColumnNames(columnCount, header, [&](int column)
-        {
-            return sheet.cell(column + 1, 0 + 1).to_string();
-        });
-        const bool useFirstRowAsHeaders = std::holds_alternative<TakeFirstRowAsHeaders>(header);
-
-        // setup column builders
-        std::vector<std::unique_ptr<ColumnBuilderBase>> columnBuilders;
-        for(auto columnType : columnTypes)
-        {
-            auto ptr = visitType(*columnType.type, [&] (auto id) -> std::unique_ptr<ColumnBuilderBase>
-            {
-                return std::make_unique<ColumnBuilder<id.value>>(columnType.nullable);
-            });
-            ptr->reserve(rowCount);
-            columnBuilders.push_back(std::move(ptr));
-        }
-        for(auto i = columnBuilders.size(); i < columnCount; i++)
-        {
-            columnBuilders.push_back(std::make_unique<ColumnBuilder<arrow::Type::STRING>>(false));
-        }
-    
-        for(int column = 0; column < columnCount; column++)
-        {
-            for(int row = useFirstRowAsHeaders; row < rowCount; row++)
-            {
-                xlnt::cell_reference cellPos(column+1, row+1);
-                if(sheet.has_cell(cellPos))
-                    columnBuilders[column]->addFromCell(sheet.cell(cellPos));
-                else
-                    columnBuilders[column]->addMissing();
-            }
-        }
-
-        std::vector<std::shared_ptr<arrow::Array>> arrays;
-        for(auto &builder : columnBuilders)
-            arrays.push_back(builder->finish());
-
-
-        return buildTable(names, arrays, columnTypes);
-
-    }
-    catch(std::exception &e)
-    {
-        throw std::runtime_error("Failed to parse file `"s + filepath + "` : " + e.what());
-    }
-}
-
-void writeXlsx(std::ostream &out, const arrow::Table &table, GeneratorHeaderPolicy headerPolicy)
-{
-    xlnt::workbook wb;
-    auto sheet = wb.active_sheet();
-    sheet.title("Table");
- 
-    if(headerPolicy == GeneratorHeaderPolicy::GenerateHeaderLine)
         for(int column = 0; column < table.num_columns(); column++)
-            sheet.cell(column + 1, 1).value(table.column(column)->name());
- 
-    for(int column = 0; column < table.num_columns(); column++)
-    {
-        int32_t row = headerPolicy == GeneratorHeaderPolicy::GenerateHeaderLine;
-        const auto writeValue = [&] (auto &&field)
         {
-            using FieldType = std::decay_t<decltype(field)>;
-            auto cell = sheet.cell(column+1, row+1);
-            // NOTE: workaround for GCC: otherwise call to xlnt::cell::value would be ambiguous
-            // as int64_t is long int and there is no such overload (just ints and long long ints)
-            if constexpr(std::is_same_v<int64_t, FieldType>)
-                cell.value((long long)field);
-            else if constexpr(std::is_same_v<std::string_view, FieldType>)
-                cell.value(std::string(field));
-            else if constexpr(std::is_same_v<Timestamp, FieldType>)
+            int32_t row = headerPolicy == GeneratorHeaderPolicy::GenerateHeaderLine;
+            const auto writeValue = [&](auto &&field)
             {
-                using namespace date;
-                auto daypoint = floor<days>(field);
-                auto ymd = year_month_day(daypoint);   // calendar date
-                time_of_day tod = make_time(field - daypoint); // Yields time_of_day type
+                using FieldType = std::decay_t<decltype(field)>;
+                auto cell = sheet.cell(column + 1, row + 1);
+                // NOTE: workaround for GCC: otherwise call to xlnt::cell::value would be ambiguous
+                // as int64_t is long int and there is no such overload (just ints and long long ints)
+                if constexpr(std::is_same_v<int64_t, FieldType>)
+                    cell.value((long long)field);
+                else if constexpr(std::is_same_v<std::string_view, FieldType>)
+                    cell.value(std::string(field));
+                else if constexpr(std::is_same_v<Timestamp, FieldType>)
+                {
+                    using namespace date;
+                    auto daypoint = floor<days>(field);
+                    auto ymd = year_month_day(daypoint);   // calendar date
+                    time_of_day tod = make_time(field - daypoint); // Yields time_of_day type
 
-                // Obtain individual components as integers
-                auto y = (int)ymd.year();
-                auto m = (int)(unsigned)ymd.month();
-                auto d = (int)(unsigned)ymd.day();
-                auto h = (int)tod.hours().count();
-                auto min = (int)tod.minutes().count();
-                auto s = (int)tod.seconds().count();
-                auto us = (int)std::chrono::duration_cast<std::chrono::microseconds>(tod.subseconds()).count();
+                                                                   // Obtain individual components as integers
+                    auto y = (int)ymd.year();
+                    auto m = (int)(unsigned)ymd.month();
+                    auto d = (int)(unsigned)ymd.day();
+                    auto h = (int)tod.hours().count();
+                    auto min = (int)tod.minutes().count();
+                    auto s = (int)tod.seconds().count();
+                    auto us = (int)std::chrono::duration_cast<std::chrono::microseconds>(tod.subseconds()).count();
 
-                xlnt::datetime timestamp{y, m, d, h, min, s, us}; // TODO: microsecond
-                cell.value(timestamp);
-            }
-            else
-                cell.value(field);
-            ++row;
-        };
-        const auto writeNull = [&]
-        {
-            ++row;
-        };
-  
-        iterateOverGeneric(*table.column(column), writeValue, writeNull);
+                    xlnt::datetime timestamp{ y, m, d, h, min, s, us }; // TODO: microsecond
+                    cell.value(timestamp);
+                }
+                else
+                    cell.value(field);
+                ++row;
+            };
+            const auto writeNull = [&]
+            {
+                ++row;
+            };
+
+            iterateOverGeneric(*table.column(column), writeValue, writeNull);
+        }
+
+        wb.save(out);
     }
-
-    wb.save(out);
 }
 
 #endif // DISABLE_XLSX
 
-void writeXlsx(const char *filepath, const arrow::Table &table, GeneratorHeaderPolicy headerPolicy /*= GeneratorHeaderPolicy::GenerateHeaderLine*/)
+std::string FormatXLSX::fileSignature() const
 {
-    auto out = openFileToWrite(filepath);
-    return writeXlsx(out, table, headerPolicy);
+    // Note: Office Open XML file format is actually just a zipped XML.
+    // Because of that we test for ZIP file signature.
+    // But that might just be some random zip or other office document (like MS Word).
+    return { 0x50, 0x4B, 0x03, 0x04 };
+}
+
+std::shared_ptr<arrow::Table> FormatXLSX::read(std::string_view filePath, const XlsxReadOptions &options) const
+{
+    try
+    {
+        auto input = openFileToRead(filePath);
+        return readXlsxInput(input, options.header, options.columnTypes);
+    }
+    catch(std::exception &e)
+    {
+        THROW("Failed to load file {} as XLSX: {}", filePath, e);
+    }
+}
+
+void FormatXLSX::write(std::string_view filePath, const arrow::Table &table, const XlsxWriteOptions &options) const
+{
+    auto out = openFileToWrite(filePath);
+    return writeXlsx(out, table, options.headerPolicy);
 }

--- a/native_libs/src/IO/XLSX.h
+++ b/native_libs/src/IO/XLSX.h
@@ -7,6 +7,23 @@ namespace arrow
     class Table;
 }
 
-DFH_EXPORT std::shared_ptr<arrow::Table> readXlsxFile(const char *filepath, HeaderPolicy header = TakeFirstRowAsHeaders{}, std::vector<ColumnType> columnTypes = {});
-DFH_EXPORT void writeXlsx(const char *filepath, const arrow::Table &table, GeneratorHeaderPolicy headerPolicy = GeneratorHeaderPolicy::GenerateHeaderLine);
-DFH_EXPORT void writeXlsx(std::ostream &out, const arrow::Table &table, GeneratorHeaderPolicy headerPolicy = GeneratorHeaderPolicy::GenerateHeaderLine);
+struct XlsxReadOptions
+{
+    HeaderPolicy header = TakeFirstRowAsHeaders{};
+    std::vector<ColumnType> columnTypes = {};
+};
+
+struct XlsxWriteOptions
+{
+    GeneratorHeaderPolicy headerPolicy = GeneratorHeaderPolicy::GenerateHeaderLine;
+};
+
+struct DFH_EXPORT FormatXLSX : TableFileHandlerWithOptions<XlsxReadOptions, XlsxWriteOptions>
+{
+    using TableFileHandler::read;
+    using TableFileHandler::write;
+
+    virtual std::string fileSignature() const override;
+    virtual std::shared_ptr<arrow::Table> read(std::string_view filePath, const XlsxReadOptions &options) const override;
+    virtual void write(std::string_view filePath, const arrow::Table &table, const XlsxWriteOptions &options) const override;
+};


### PR DESCRIPTION
The primary issue solved by this PR is #66 — allowing user to "just read" the file without specifying its format. The interface was already there, it just assumed always CSV. Now all the supported formats should be recognized: CSV, Apache Feather and XLSX. 

This PR also refactors the internal C++ interface of IO code. Support for CSV, Feather and XLSX were added separately, each with its own set of slightly differently named functions. This PR unifies them under a common interface, for easier usage, consistence and possible code reuse across all 3 format IO.

Ref #57

Fixes #66 