### PR TITLE
Fixing legend boxes in charts

### DIFF
--- a/native_libs/plotter/Matplotlib/Plot.cpp
+++ b/native_libs/plotter/Matplotlib/Plot.cpp
@@ -113,7 +113,6 @@ pybind11::list toPyList(const arrow::Table &table)
 std::string getPNG()
 {
     plt::tight_layout();
-    plt::legend();
     return plt::getPNG();
 }
 
@@ -125,8 +124,6 @@ extern "C"
         {
             auto xsarray = toPyList(*xs);
             auto ysarray = toPyList(*ys);
-            pybind11::print(xsarray);
-            pybind11::print(ysarray);
             plt::plot(xsarray, ysarray, label, style, color, alpha);
         };
     }
@@ -137,8 +134,6 @@ extern "C"
         {
             auto xsarray = toPyList(*xs);
             auto ysarray = toPyList(*ys);
-            pybind11::print(xsarray);
-            pybind11::print(ysarray);
             plt::plot_date(xsarray, ysarray);
         };
     }

--- a/native_libs/third-party/matplotlib-cpp/matplotlibcpp.h
+++ b/native_libs/third-party/matplotlib-cpp/matplotlibcpp.h
@@ -147,6 +147,9 @@ private:
 
 } // end namespace detail
 
+
+void legendIfLabelPresent(std::string_view label);
+
 // must be called before the first regular call to matplotlib to have any effect
 inline void backend(const std::string& name)
 {
@@ -269,6 +272,7 @@ void fill_between(pybind11::list xarray, pybind11::list yarray1, pybind11::list 
         insert(kwargs, "color", color);
 
     detail::_interpreter::get().s_python_function_fill_between(xarray, yarray1, yarray2, **kwargs);
+    legendIfLabelPresent(label);
 }
 
 void scatter(pybind11::list xarray, pybind11::list yarray)
@@ -421,6 +425,7 @@ void kdeplot(pybind11::list xarray, const char* label)
         insert(kwargs, "label", pybind11::str(label));
 
     detail::_interpreter::get().s_python_function_kdeplot(xarray, **kwargs);
+    legendIfLabelPresent(label);
 }
 
 void plot(pybind11::list xarray, pybind11::list yarray, std::string_view label, std::string_view format = "", std::string_view color = "", double alpha = 1.0)
@@ -433,6 +438,7 @@ void plot(pybind11::list xarray, pybind11::list yarray, std::string_view label, 
     insert(kwargs, "alpha", pybind11::float_(alpha));
 
     auto lines = detail::_interpreter::get().s_python_function_plot(xarray, yarray, format, **kwargs);
+    legendIfLabelPresent(label);
 }
 // 
 // template<typename NumericX, typename NumericY>
@@ -746,10 +752,16 @@ inline void rotate_ticks(long rot)
 {
     detail::_interpreter::get().s_python_function_xticks("rotation"_a = rot, "ha"_a = "right");
 }
- 
+
 inline void legend()
 {
     detail::_interpreter::get().s_python_function_legend();
+}
+
+inline void legendIfLabelPresent(std::string_view label)
+{
+    if(!label.empty())
+        legend();
 }
 // 
 // template<typename Numeric>


### PR DESCRIPTION
This PR fixes how our bindings to matplotlib handle creation legend box with labels. Instead of blindly calling legend() when obtaining the final image and hope it makes sense, we call it when adding a plot with a label. This fixes two issues:
1) When we have multiple plots in a single image, each will have its own legend
2) When we have no labels, no legend box shall be created ( that fixes #51 ).

The screenshot below shows the fix: on the left the chart does not have an empty legend box, on the right we have two charts, each with their own legend box.
![obraz](https://user-images.githubusercontent.com/1548407/46963298-930bb780-d0a5-11e8-85bc-dfd67a4e45db.png)
