### PR TITLE
Luna operations creating table from columns will adjust column length by padding with nulls

### DIFF
--- a/native_libs/src/Core/ArrowUtilities.h
+++ b/native_libs/src/Core/ArrowUtilities.h
@@ -678,6 +678,7 @@ std::shared_ptr<arrow::Schema> setNullable(bool nullable, std::shared_ptr<arrow:
 using PossiblyChunkedArray = std::variant<std::shared_ptr<arrow::Array>, std::shared_ptr<arrow::ChunkedArray>>;
 
 DFH_EXPORT std::shared_ptr<arrow::Table> tableFromArrays(std::vector<PossiblyChunkedArray> arrays, std::vector<std::string> names = {}, std::vector<bool> nullables = {});
+DFH_EXPORT std::shared_ptr<arrow::Table> tableFromColumns(const std::vector<std::shared_ptr<arrow::Column>> &columns, const std::shared_ptr<arrow::Schema> &schema);
 DFH_EXPORT std::shared_ptr<arrow::Table> tableFromColumns(const std::vector<std::shared_ptr<arrow::Column>> &columns);
 
 template<typename ...Ts>

--- a/native_libs/src/main.cpp
+++ b/native_libs/src/main.cpp
@@ -989,14 +989,14 @@ extern "C"
 // TABLE
 extern "C"
 {
-    DFH_EXPORT arrow::Table *tableNewFromSchamColumns(arrow::Schema *schema, const arrow::Column **columns, int32_t columnCount, const char **outError) noexcept
+    DFH_EXPORT arrow::Table *tableNewFromSchemaAndColumns(const arrow::Schema *schema, const arrow::Column **columns, int32_t columnCount, const char **outError) noexcept
     {
         LOG("{} {} {}", (void*)schema, (void*)columns, columnCount);
         return TRANSLATE_EXCEPTION(outError)
         {
             auto managedSchema = LifetimeManager::instance().accessOwned(schema);
             auto managedColumns = LifetimeManager::instance().accessOwnedArray(columns, columnCount);
-            auto ret = arrow::Table::Make(managedSchema, managedColumns);
+            auto ret = tableFromColumns(managedColumns, managedSchema);
             return LifetimeManager::instance().addOwnership(std::move(ret));
         };
     }

--- a/src/Internal/CWrappers.luna
+++ b/src/Internal/CWrappers.luna
@@ -388,7 +388,7 @@ class TableWrapper:
 
 def createTableWrapper schemaWrapper columnWrappers:
     Array (Pointer None) . with (columnWrappers.each (_.ptr . ptr)) columnsCArray:
-        ptr = callHandlingError "tableNewFromSchamColumns" (Pointer None) [schemaWrapper.ptr . toCArg, columnsCArray.ptr.toCArg, CInt32.fromInt columnsCArray.size . toCArg]
+        ptr = callHandlingError "tableNewFromSchemaAndColumns" (Pointer None) [schemaWrapper.ptr . toCArg, columnsCArray.ptr.toCArg, CInt32.fromInt columnsCArray.size . toCArg]
         wrapReleasableResouce TableWrapper ptr
 
 def readTableFromFile path:


### PR DESCRIPTION
The function with padding was already done, by some mistake it wasn't properly connected to the Luna bindings.