### PR TITLE
Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ cache:
 init:
 
 build_script:
-- python -mpip install numpy
+- python -m pip install numpy
 - curl -sS -ostack.zip -L --insecure https://get.haskellstack.org/stable/windows-i386.zip
 - 7z x stack.zip stack.exe
 - stack --arch x86_64 %APPVEYOR_BUILD_FOLDER%\scripts\Package.hs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,5 +26,6 @@ deploy:
     secret_access_key:
       secure: /ALZ8SK6q7DFtIN1cU4+jM3KAIFY1/AVEZOyL3lCuSDynKxr/zDZLwAuPgieeE0r
     bucket: packages-luna
+    region: us-west-2
     folder: dataframes/nightly/$(APPVEYOR_REPO_COMMIT)
     artifact: Dataframes-Win-x64-v141

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,6 @@ build_script:
 - 7z x stack.zip stack.exe
 - stack --arch x86_64 %APPVEYOR_BUILD_FOLDER%\scripts\Package.hs
 
-test_script:
-- "%APPVEYOR_BUILD_FOLDER%\\native_libs\\src\\x64\\Release\\DataframeHelperTests --log_level=all"
-
 artifacts:
 - path: Dataframes-Win-x64-v141.7z
   name: Dataframes-Win-x64-v141

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,13 +8,14 @@ cache:
 - C:\Users\appveyor\AppData\Roaming\stack\
 - C:\Users\appveyor\AppData\Local\Programs\stack
 
-init:
-
 build_script:
 - python -m pip install numpy
 - curl -sS -o stack.zip -L --insecure https://get.haskellstack.org/stable/windows-i386.zip
 - 7z x stack.zip stack.exe
 - stack --arch x86_64 %APPVEYOR_BUILD_FOLDER%\scripts\Package.hs
+
+test_script:
+- $(APPVEYOR_REPO_COMMIT)\native_libs\src\x64\Release\DataframeHelperTests --log_level=all
 
 artifacts:
 - path: Dataframes-Win-x64-v141.7z

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+environment:
+  PATH: C:\Python37-x64;%PATH%
+  PythonDir: C:\Python37-x64
+
+cache:
+- C:\Users\appveyor\AppData\Roaming\stack\
+- C:\Users\appveyor\AppData\Local\Programs\stack
+
+init:
+
+build_script:
+- python -mpip install numpy
+- curl -sS -ostack.zip -L --insecure https://get.haskellstack.org/stable/windows-i386.zip
+- 7z x stack.zip stack.exe
+- stack --arch x86_64 %APPVEYOR_BUILD_FOLDER%\scripts\Package.hs
+
+artifacts:
+- path: Dataframes-Win-x64-v141.7z
+  name: Dataframes package

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ deploy:
   - provider: S3
     access_key_id: AKIAIFQRMRF6E4OOZNMQ
     secret_access_key:
-      secure: cQn33zlkEHmPJHNplsHXEUyYeTZrHf2nVcSh2XbQlSo6jVrGhFtFt0AUcAJmqfyJ
+      secure: /ALZ8SK6q7DFtIN1cU4+jM3KAIFY1/AVEZOyL3lCuSDynKxr/zDZLwAuPgieeE0r
     bucket: packages-luna
     folder: dataframes/nightly/$(APPVEYOR_REPO_COMMIT)
     artifact: Dataframes-Win-x64-v141

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,3 +29,4 @@ deploy:
     region: us-west-2
     folder: dataframes/nightly/$(APPVEYOR_REPO_COMMIT)
     artifact: Dataframes-Win-x64-v141
+    set_public: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build_script:
 - stack --arch x86_64 %APPVEYOR_BUILD_FOLDER%\scripts\Package.hs
 
 test_script:
-- "%APPVEYOR_REPO_COMMIT%\\native_libs\\src\\x64\\Release\\DataframeHelperTests --log_level=all"
+- "%APPVEYOR_BUILD_FOLDER%\\native_libs\\src\\x64\\Release\\DataframeHelperTests --log_level=all"
 
 artifacts:
 - path: Dataframes-Win-x64-v141.7z

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ init:
 
 build_script:
 - python -m pip install numpy
-- curl -sS -ostack.zip -L --insecure https://get.haskellstack.org/stable/windows-i386.zip
+- curl -sS -o stack.zip -L --insecure https://get.haskellstack.org/stable/windows-i386.zip
 - 7z x stack.zip stack.exe
 - stack --arch x86_64 %APPVEYOR_BUILD_FOLDER%\scripts\Package.hs
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,4 +27,3 @@ deploy:
     region: us-west-2
     folder: dataframes/nightly/$(APPVEYOR_REPO_COMMIT)
     artifact: Dataframes-Win-x64-v141
-    set_public: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,4 +18,13 @@ build_script:
 
 artifacts:
 - path: Dataframes-Win-x64-v141.7z
-  name: Dataframes package
+  name: Dataframes-Win-x64-v141
+
+deploy:
+  - provider: S3
+    access_key_id: AKIAIFQRMRF6E4OOZNMQ
+    secret_access_key:
+      secure: cQn33zlkEHmPJHNplsHXEUyYeTZrHf2nVcSh2XbQlSo6jVrGhFtFt0AUcAJmqfyJ
+    bucket: packages-luna
+    folder: dataframes/nightly/$(APPVEYOR_REPO_COMMIT)
+    artifact: Dataframes-Win-x64-v141

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build_script:
 - stack --arch x86_64 %APPVEYOR_BUILD_FOLDER%\scripts\Package.hs
 
 test_script:
-- $(APPVEYOR_REPO_COMMIT)\native_libs\src\x64\Release\DataframeHelperTests --log_level=all
+- "%APPVEYOR_REPO_COMMIT%\\native_libs\\src\\x64\\Release\\DataframeHelperTests --log_level=all"
 
 artifacts:
 - path: Dataframes-Win-x64-v141.7z

--- a/native_libs/src/Dataframe.props
+++ b/native_libs/src/Dataframe.props
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ImportGroup Label="PropertySheets" />
+  <ImportGroup Label="PropertySheets">
+    <Import Condition="exists('C:\deps\libraries.props')" Project="C:\deps\libraries.props" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <IncludePath>$(SolutionDir);$(SolutionDir)\..\third-party\variant-lite;$(SolutionDir)\..\third-party\any-lite;$(SolutionDir);$(IncludePath)</IncludePath>
@@ -38,7 +40,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-    <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <Link>
       <AdditionalDependencies>fmt.lib;arrowd.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>

--- a/native_libs/src/Dataframe.props
+++ b/native_libs/src/Dataframe.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets">
-    <Import Condition="exists('C:\deps\libraries.props')" Project="C:\deps\libraries.props" />
+    <Import Project="$(DATAFRAMES_DEPS_DIR)\*.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>

--- a/scripts/Package.hs
+++ b/scripts/Package.hs
@@ -106,8 +106,6 @@ main = do
         when (null builtExes) $ error "Missing built EXE!"
         sequence $ copyToDir packageBinaries <$> builtDlls
         mapM (copyToDir packageBinaries) (builtDlls <> builtExes)
-        copyDirectory repoDir packageRoot "src"
-        copyDirectory repoDir packageRoot "visualizers"
         let dirsToCopy = ["src", "visualizers", ".luna-package"]
         mapM (copyDirectory repoDir packageRoot) dirsToCopy
         pack7z [packageRoot] $ packageFile

--- a/scripts/Package.hs
+++ b/scripts/Package.hs
@@ -17,10 +17,8 @@ import System.FilePath.Glob
 import System.IO.Temp
 import System.Process
 
-depsArchiveUrl :: String
+depsArchiveUrl, packageBaseUrl :: String
 depsArchiveUrl = "https://s3-us-west-2.amazonaws.com/packages-luna/dataframes/libs-dev-v140.7z"
-
-packageBaseUrl :: String
 packageBaseUrl = "https://s3-us-west-2.amazonaws.com/packages-luna/dataframes/windows-package-base.7z"
 
 getEnvDefault :: String -> String -> IO String
@@ -40,9 +38,7 @@ find7z = do
     findProgram [ProgramSearchPathDefault, ProgramSearchPathDir default7zPath] "7z"
 
 get7zPath :: IO FilePath
-get7zPath = find7z >>= \case
-    Just programPath -> return programPath
-    Nothing          -> error errorMsg
+get7zPath = fromMaybe (error errorMsg) <$> find7z
     where errorMsg = "cannot find 7z, please install from https://7-zip.org.pl/ or make sure that program is visible in PATH"
 
 unpack7z :: FilePath -> FilePath -> IO ()
@@ -68,8 +64,7 @@ copyToDir destDir sourcePath = do
     copyFile sourcePath destPath
 
 pushArtifact :: FilePath -> IO ()
-pushArtifact path = do
-    callProcess "appveyor" ["PushArtifact", path]
+pushArtifact path = callProcess "appveyor" ["PushArtifact", path]
 
 -- Function downloads 7z to temp folder, so it doesn't leave any trash behind.
 downloadAndUnpack7z :: FilePath -> FilePath -> IO ()

--- a/scripts/Package.hs
+++ b/scripts/Package.hs
@@ -18,10 +18,10 @@ import System.IO.Temp
 import System.Process
 
 depsArchiveUrl :: String
-depsArchiveUrl = "https://packages.luna-lang.org/dataframes/libs-dev-v140.7z"
+depsArchiveUrl = "https://s3-us-west-2.amazonaws.com/packages-luna/dataframes/libs-dev-v140.7z"
 
 packageBaseUrl :: String
-packageBaseUrl = "https://packages.luna-lang.org/dataframes/windows-package-base.7z"
+packageBaseUrl = "https://s3-us-west-2.amazonaws.com/packages-luna/dataframes/windows-package-base.7z"
 
 getEnvDefault :: String -> String -> IO String
 getEnvDefault variableName defaultValue =

--- a/scripts/Package.hs
+++ b/scripts/Package.hs
@@ -1,0 +1,86 @@
+#!/usr/bin/env stack
+-- stack --resolver lts-12.12 script --package Cabal,directory,extra,filepath,Glob,process,temporary
+
+{-# LANGUAGE LambdaCase #-}
+
+import Control.Monad
+import Control.Monad.Extra
+import Data.Maybe
+import Data.Monoid
+import Distribution.Simple.Program.Find
+import Distribution.Simple.Utils
+import Distribution.Verbosity
+import System.Directory
+import System.Environment
+import System.FilePath
+import System.Process
+import System.FilePath.Glob
+import System.IO.Temp
+
+packageBaseUrl = "https://s3-us-west-2.amazonaws.com/packages-luna/dataframes/windows-package-base.7z"
+
+getEnvDefault :: String -> String -> IO String
+getEnvDefault variableName defaultValue = fromMaybe defaultValue <$> lookupEnv variableName
+
+findProgram :: ProgramSearchPath -> String -> IO (Maybe FilePath)
+findProgram whereToSearch name = do
+    fmap fst <$> findProgramOnSearchPath silent whereToSearch name
+
+download :: String -> FilePath -> IO ()
+download url destPath = callProcess "curl" ["-fSL", "-o", destPath, url]
+
+find7z :: IO (Maybe FilePath)
+find7z = findProgram [ProgramSearchPathDefault, ProgramSearchPathDir default7zPath] "7z"
+    where default7zPath = "C:\\Program Files\\7-Zip"
+
+get7z :: IO FilePath
+get7z = find7z >>= \case
+    Just programPath -> return programPath
+    Nothing          -> error "cannot find 7z, please install from https://7-zip.org.pl/ or make sure that program is visible in PATH"
+
+unpack7z :: FilePath -> FilePath -> IO ()
+unpack7z archive outputDirectory = do
+    programPath <- get7z
+    callProcess programPath ["x", "-y", "-o" <> outputDirectory, archive]
+
+pack7z :: [FilePath] -> FilePath -> IO ()
+pack7z packedPaths outputArchivePath = do
+    programPath <- get7z
+    callProcess programPath $ ["a", "-y", outputArchivePath] <> packedPaths
+
+buildWithMsBuild solutionPath = do
+    let msbuildPath = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\amd64\\MSBuild.exe"
+    callProcess msbuildPath ["/property:Configuration=Release", solutionPath]
+
+copyToDir destDir sourcePath = do
+    createDirectoryIfMissing True destDir
+    putStrLn $ "Copy " ++ sourcePath ++ " to " ++ destDir
+    let destPath = destDir </> takeFileName sourcePath
+    copyFile sourcePath destPath
+
+pushArtifact path = do
+    callProcess "appveyor" ["PushArtifact", path]
+
+main = do
+    repoDir <- getEnvDefault "APPVEYOR_BUILD_FOLDER" "C:\\dev\\Dataframes"
+    buildWithMsBuild (repoDir </> "native_libs" </> "src" </> "DataframeHelper.sln")
+    withSystemTempDirectory "" $ \stagingDir -> do
+        let packageRoot = stagingDir </> "Dataframes"
+        let packageBinaries = packageRoot </> "native_libs" </> "windows"
+        let packageArchive = stagingDir </> "package.7z"
+        let builtBinariesDir = repoDir </> "native_libs" </> "src" </> "x64" </> "Release"
+        let packageFile = "Dataframes-Win-x64-v141" <.> "7z"
+
+        download packageBaseUrl packageArchive
+        unpack7z packageArchive packageBinaries
+        builtDlls <- glob (builtBinariesDir </> "*.dll")
+        builtExes <- glob (builtBinariesDir </> "*.exe")
+        when (null builtDlls) $ error "Missing built DLL!"
+        when (null builtExes) $ error "Missing built EXE!"
+        sequence $ copyToDir packageBinaries <$> builtDlls
+        sequence $ copyToDir packageBinaries <$> builtExes
+        copyDirectoryRecursive silent (repoDir </> "src") (packageRoot </> "src")
+        copyDirectoryRecursive silent (repoDir </> "visualizers") (packageRoot </> "visualizers")
+        pack7z [packageRoot] $ packageFile
+        putStrLn $ "Packaging done, file saved to: " <> packageFile
+        -- getLine

--- a/scripts/Package.hs
+++ b/scripts/Package.hs
@@ -18,10 +18,10 @@ import System.IO.Temp
 import System.Process
 
 depsArchiveUrl :: String
-depsArchiveUrl = "https://s3-us-west-2.amazonaws.com/packages-luna/dataframes/libs-dev-v140.7z"
+depsArchiveUrl = "https://packages.luna-lang.org/dataframes/libs-dev-v140.7z"
 
 packageBaseUrl :: String
-packageBaseUrl = "https://s3-us-west-2.amazonaws.com/packages-luna/dataframes/windows-package-base.7z"
+packageBaseUrl = "https://packages.luna-lang.org/dataframes/windows-package-base.7z"
 
 getEnvDefault :: String -> String -> IO String
 getEnvDefault variableName defaultValue =

--- a/scripts/Package.hs
+++ b/scripts/Package.hs
@@ -105,7 +105,7 @@ main = do
         when (null builtDlls) $ error "Missing built DLL!"
         when (null builtExes) $ error "Missing built EXE!"
         sequence $ copyToDir packageBinaries <$> builtDlls
-        sequence $ copyToDir packageBinaries <$> builtExes
+        mapM (copyToDir packageBinaries) (builtDlls <> builtExes)
         copyDirectory repoDir packageRoot "src"
         copyDirectory repoDir packageRoot "visualizers"
         copyDirectory repoDir packageRoot ".luna-package"

--- a/scripts/Package.hs
+++ b/scripts/Package.hs
@@ -108,7 +108,8 @@ main = do
         mapM (copyToDir packageBinaries) (builtDlls <> builtExes)
         copyDirectory repoDir packageRoot "src"
         copyDirectory repoDir packageRoot "visualizers"
-        copyDirectory repoDir packageRoot ".luna-package"
+        let dirsToCopy = ["src", "visualizers", ".luna-package"]
+        mapM (copyDirectory repoDir packageRoot) dirsToCopy
         pack7z [packageRoot] $ packageFile
         putStrLn $ "Packaging done, file saved to: " <> packageFile
         -- getLine

--- a/scripts/Package.hs
+++ b/scripts/Package.hs
@@ -105,6 +105,7 @@ main = do
         sequence $ copyToDir packageBinaries <$> builtExes
         copyDirectory repoDir packageRoot "src"
         copyDirectory repoDir packageRoot "visualizers"
+        copyDirectory repoDir packageRoot ".luna-package"
         pack7z [packageRoot] $ packageFile
         putStrLn $ "Packaging done, file saved to: " <> packageFile
         -- getLine

--- a/scripts/Package.hs
+++ b/scripts/Package.hs
@@ -110,7 +110,6 @@ main = do
         builtExes <- glob (builtBinariesDir </> "*.exe")
         when (null builtDlls) $ error "Missing built DLL!"
         when (null builtExes) $ error "Missing built EXE!"
-        sequence $ copyToDir packageBinaries <$> builtDlls
         mapM (copyToDir packageBinaries) (builtDlls <> builtExes)
         let dirsToCopy = ["src", "visualizers", ".luna-package"]
         mapM (copyDirectory repoDir packageRoot) dirsToCopy

--- a/scripts/Package.hs
+++ b/scripts/Package.hs
@@ -100,8 +100,8 @@ copyDirectory sourceDirectory targetDirectory subdirectoryFilename = do
 
 main :: IO ()
 main = do
---     withSystemTempDirectory "" $ \stagingDir -> do
-        let stagingDir = "C:\\Users\\mwurb\\AppData\\Local\\Temp\\-777f232250ff9e9c"
+    withSystemTempDirectory "" $ \stagingDir -> do
+        -- let stagingDir = "C:\\Users\\mwurb\\AppData\\Local\\Temp\\-777f232250ff9e9c"
         prepareEnvironment stagingDir
 
         repoDir <- getEnvDefault "APPVEYOR_BUILD_FOLDER" "C:\\dev\\Dataframes"

--- a/scripts/Package.hs
+++ b/scripts/Package.hs
@@ -13,9 +13,9 @@ import Distribution.Verbosity
 import System.Directory
 import System.Environment
 import System.FilePath
-import System.Process
 import System.FilePath.Glob
 import System.IO.Temp
+import System.Process
 
 packageBaseUrl = "https://s3-us-west-2.amazonaws.com/packages-luna/dataframes/windows-package-base.7z"
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@ This directory contains the `Package.hs` script.
 
 The script is provisional, Windows-only and relies on archives prepared beforehand. The aim is to iteratively improve and generalize it, in compliance with our long-term libraries package & distribution vision.
 
-## Package.hs
+# Package.hs
 Running this script builds the Dataframes library and creates a relocatable package with binary artifacts.
 
 Script can be run by calling:
@@ -12,9 +12,10 @@ stack repo\scripts\Package.hs
 
 The script can be called from any location, the artifacts will appear in current working directory.
 
-### Input
+## Input
 * local environment:
   * Dataframes repository copy under the path stored in environment variable `APPVEYOR_BUILD_FOLDER`
+  * Visual Studio C++ toolset (2017.8)
   * MS Build binary under the path `C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\amd64\MSBuild.exe` (part of Visual Studio installation)
   * `7z` program either available in `PATH` or installed in `C:\Program Files\7-Zip` (the default installation path)
   * `curl` program available in `PATH` (present by default on newer Windows)
@@ -23,12 +24,12 @@ The script can be called from any location, the artifacts will appear in current
   * archive with build-time dependencies (import libraries, headers, binaries), currently assumed at: `https://s3-us-west-2.amazonaws.com/packages-luna/dataframes/libs-dev-v140.7z`
   * archive with package skeleton (i. e. package sans Dataframes library itself), currently assumed at: `https://s3-us-west-2.amazonaws.com/packages-luna/dataframes/windows-package-base.7z`
 
-### Output
+## Output
 In the current working directory:
 * `Dataframes-Win-x64-v141.7z` file — relocatable Dataframe library package (and all its dependencies) for 64-bit Windows.
 
-### How the input packages are built
-#### Build-time dependencies
+## How the input packages are built
+### Build-time dependencies
 Contains the following libraries:
 * Apache Arrow
 * Boost
@@ -42,14 +43,18 @@ Each library comes with its own MS Build project property sheet that makes libra
 
 Dependencies were built manually and appropriately structured. The process should eventually become fully automated.
 
-There is an additional property sheet for Python, that adds Python installation that is placed under the location stored in `PythonDir` environment variable.
+There is an additional property sheet for Python, that adds Python installation that is placed under the location stored in `PythonDir` environment variable. Python and numpy is not part of this package, but if the variable is set, this package exposes Python and numpy to MSBuild.
 
-#### Package skeleton
+All binaries are built with latest Visual Studio C++ compiler (as of writing, 15.8.7). They are 64-bit and use dynamic threaded runtime. Both Debug and Relase binaries are provided.
+
+### Package skeleton
 It basically consists of three parts:
 * Python and its packages
 * Other C/C++ library dependencies binaries
 * runtime binaries
 
+
+#### Python
 Python parts can packaged using the following batch script:
 ```
 curl -fsL -o python-3.7.0-embed-amd64.zip https://www.python.org/ftp/python/3.7.0/python-3.7.0-embed-amd64.zip
@@ -62,12 +67,14 @@ del get-pip.py
 .\python.exe -mpip install numpy seaborn matplotlib
 ```
 
+#### C and C++ dependencies
 C and C++ dependencies are packaged just by copying their dependencies. In typical scenario it involves copying:
 * Arrow.dll
 * xlnt.dll
 
 from the build-time dependencies package. That's assuming all other libraries are either static or header only. In some setups libraries like Boost, date and {fmt} may have their .DLL files as well.
 
+#### Runtime libraries
 Placing runtime libraries is just basically copying all DLL files from two folders:
 * Universal C Runtime (UCRT) comes with Windows SDK. It has all the libraries named like `api-ms-win-*-*-l1-1-0.dll` and `ucrtbase.dll`. The source location depends on Windows SDK version installed on the building machine, following schema like `C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\x64`.
 * Visual C++ Redistributable — the exact path depends on VS installation path, it is like: `C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.15.26706\x64\Microsoft.VC141.CRT`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,73 @@
+This directory contains the `Package.hs` script.
+
+The script is provisional, Windows-only and relies on archives prepared beforehand. The aim is to iteratively improve and generalize it, in compliance with our long-term libraries package & distribution vision.
+
+## Package.hs
+Running this script builds the Dataframes library and creates a relocatable package with binary artifacts.
+
+Script can be run by calling:
+```
+stack repo\scripts\Package.hs
+```
+
+The script can be called from any location, the artifacts will appear in current working directory.
+
+### Input
+* local environment:
+  * Dataframes repository copy under the path stored in environment variable `APPVEYOR_BUILD_FOLDER`
+  * MS Build binary under the path `C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\amd64\MSBuild.exe` (part of Visual Studio installation)
+  * `7z` program either available in `PATH` or installed in `C:\Program Files\7-Zip` (the default installation path)
+  * `curl` program available in `PATH` (present by default on newer Windows)
+  * Python 3 with numpy package installed under a path stored in `PythonDir` environment variable.
+* hand-made resources:
+  * archive with build-time dependencies (import libraries, headers, binaries), currently assumed at: `https://s3-us-west-2.amazonaws.com/packages-luna/dataframes/libs-dev-v140.7z`
+  * archive with package skeleton (i. e. package sans Dataframes library itself), currently assumed at: `https://s3-us-west-2.amazonaws.com/packages-luna/dataframes/windows-package-base.7z`
+
+### Output
+In the current working directory:
+* `Dataframes-Win-x64-v141.7z` file — relocatable Dataframe library package (and all its dependencies) for 64-bit Windows.
+
+### How the input packages are built
+#### Build-time dependencies
+Contains the following libraries:
+* Apache Arrow
+* Boost
+* {fmt}
+* xlnt
+* date
+* rapidjson
+* pybind11
+
+Each library comes with its own MS Build project property sheet that makes library visible to build system (by adjusting include/library dirs).
+
+Dependencies were built manually and appropriately structured. The process should eventually become fully automated.
+
+There is an additional property sheet for Python, that adds Python installation that is placed under the location stored in `PythonDir` environment variable.
+
+#### Package skeleton
+It basically consists of three parts:
+* Python and its packages
+* Other C/C++ library dependencies binaries
+* runtime binaries
+
+Python parts can packaged using the following batch script:
+```
+curl -fsL -o python-3.7.0-embed-amd64.zip https://www.python.org/ftp/python/3.7.0/python-3.7.0-embed-amd64.zip
+"C:\\Program Files\\7-Zip\\7z" x -y  python-3.7.0-embed-amd64.zip
+del python-3.7.0-embed-amd64.zip
+ECHO .\lib\site-packages>>"python37._pth"
+curl -fsL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+.\python.exe get-pip.py
+del get-pip.py
+.\python.exe -mpip install numpy seaborn matplotlib
+```
+
+C and C++ dependencies are packaged just by copying their dependencies. In typical scenario it involves copying:
+* Arrow.dll
+* xlnt.dll
+
+from the build-time dependencies package. That's assuming all other libraries are either static or header only. In some setups libraries like Boost, date and {fmt} may have their .DLL files as well.
+
+Placing runtime libraries is just basically copying all DLL files from two folders:
+* Universal C Runtime (UCRT) comes with Windows SDK. It has all the libraries named like `api-ms-win-*-*-l1-1-0.dll` and `ucrtbase.dll`. The source location depends on Windows SDK version installed on the building machine, following schema like `C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\x64`.
+* Visual C++ Redistributable — the exact path depends on VS installation path, it is like: `C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.15.26706\x64\Microsoft.VC141.CRT`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,7 +22,9 @@ The script can be called from any location, the artifacts will appear in current
   * Python 3 with numpy package installed under a path stored in `PythonDir` environment variable.
 * hand-made resources:
   * archive with build-time dependencies (import libraries, headers, binaries), currently assumed at: `https://s3-us-west-2.amazonaws.com/packages-luna/dataframes/libs-dev-v140.7z`
+    * it contains .props file (property sheet) — this file will be included by MSBuild script. It is required that this sheet provides all the build-time dependencies of C++ parts of Dataframes
   * archive with package skeleton (i. e. package sans Dataframes library itself), currently assumed at: `https://s3-us-west-2.amazonaws.com/packages-luna/dataframes/windows-package-base.7z`
+    * this archive will be a skeleton for `Dataframes\native_libs\windows` directory in the redistributable package
 
 ## Output
 In the current working directory:
@@ -39,7 +41,7 @@ Contains the following libraries:
 * rapidjson
 * pybind11
 
-Each library comes with its own MS Build project property sheet that makes library visible to build system (by adjusting include/library dirs).
+Each library comes with its own MS Build project property sheet that makes library visible to build system (by adjusting include/library dirs). The archive provides all-in-one .props file in its root path. It is required that Dataframes can be built with MSVC when the file is included.
 
 Dependencies were built manually and appropriately structured. The process should eventually become fully automated.
 
@@ -53,6 +55,7 @@ It basically consists of three parts:
 * Other C/C++ library dependencies binaries
 * runtime binaries
 
+It is expected that Dataframes binaries placed in the directory with package skeleton can be run by system without any additional environment requirements.
 
 #### Python
 Python parts can packaged using the following batch script:


### PR DESCRIPTION
Note: this is still WIP as S3 integration is not working yet. Nevertheless it is a good moment to present the results and ask for feedback.

This PR adds automatic build & package capability for AppVeyor (Windows). The build artifact is a relocatable package, that can be opened in Luna Studio on any Windows machine and used to run Dataframes without any additional dependencies. The package contains all Dataframes dependencies, including Apache Arrow, Python interpreter (with matplotlib and numpy) and more.

The aim is that each commit to master will get built with AppVeyor and have package uploaded to S3 storage, from where Luna Studio packager will be able to get it. As of writing, the package is available as artifact in appveyor page, see: https://ci.appveyor.com/project/lunalangCI/dataframes/builds/19553881/artifacts

This PR consits of 3 elements:
1) scripts\Package.hs — a script that builds and packages Dataframes
2) scripts\README.md — description of the script and its inputs
3) appveyor.yml — configuration file for AppVeyor

Please note that getting Dataframes (and eventually other Luna Libraries) is a long-term effort. This is not how the packaging definition will look like nor how the package layout will look like. 

The purposes for the current PR are following:
1) it enables CI on Windows
2) it enables building Windows packages with Dataframes
3) it describes the process of packaging Dataframes on Windows and automates its significant part.

Future work:
* getting AppVeyor to run C++ tests
* further automation (particularly 
* support for other platforms and better organization of build script (likely should be full-fledged Haskell package)
* generalization of build program over the built/packaged library, splitting it into recipe and executor and promoting to a separate project

Fixes #21 and #67.