### PR TITLE
Fix division by zero when calling toJSON on an empty table. Fixes #64

### DIFF
--- a/src/Table.luna
+++ b/src/Table.luna
@@ -351,7 +351,7 @@ class Table:
         leftCount = self.rowCount - count
         self.slice count leftCount
     def toJSON:
-        maxCount = 1000 / self.columnCount
+        maxCount = 1000 / (if self.columnCount > 0 then self.columnCount else 1)
         mc = if maxCount < 10 then 10 else maxCount
         rowCount = if self.rowCount < mc then self.rowCount else mc
         cols = self.toList


### PR DESCRIPTION
As in title.