### PR TITLE
Packages uploaded to S3 are publically readable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           name: "S3 upload"
           command: |
             /python-dist/bin/python3 -mpip install awscli --user
-            aws --region us-west-2 s3 cp scripts/Dataframes-Linux-x64.tar.gz s3://packages-luna/dataframes/nightly/$CIRCLE_SHA1/Dataframes-Linux-x64.tar.gz
+            aws --region us-west-2 s3 cp scripts/Dataframes-Linux-x64.tar.gz s3://packages-luna/dataframes/nightly/$CIRCLE_SHA1/Dataframes-Linux-x64.tar.gz --acl public-read
 
 workflows:
   version: 2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,3 +29,4 @@ deploy:
     region: us-west-2
     folder: dataframes/nightly/$(APPVEYOR_REPO_COMMIT)
     artifact: $(APPVEYOR_BUILD_FOLDER)\scripts\Dataframes-Win-x64-v141
+    set_public: true


### PR DESCRIPTION
As discussed earlier — there is no reason to hide our build artifacts. 