### PR TITLE
Unify package name

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,8 @@ build_script:
 - stack run
 
 artifacts:
-- path: scripts\Dataframes-Win-x64-v141.7z
-  name: Dataframes-Win-x64-v141
+- path: scripts\Dataframes-Win-x64.7z
+  name: Dataframes-Win-x64
 
 deploy:
   - provider: S3
@@ -28,4 +28,4 @@ deploy:
     bucket: packages-luna
     region: us-west-2
     folder: dataframes/nightly/$(APPVEYOR_REPO_COMMIT)
-    artifact: $(APPVEYOR_BUILD_FOLDER)\scripts\Dataframes-Win-x64-v141
+    artifact: Dataframes-Win-x64

--- a/scripts/Main.hs
+++ b/scripts/Main.hs
@@ -75,7 +75,7 @@ nativeLibsOsDir = case buildOS of
 
 dataframesPackageName :: String
 dataframesPackageName = case buildOS of
-    Windows -> "Dataframes-Win-x64-v141.7z"
+    Windows -> "Dataframes-Win-x64.7z"
     Linux   -> "Dataframes-Linux-x64.tar.gz"
     _       -> error $ "dataframesPackageName: not implemented: " <> show buildOS
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,7 +40,7 @@ Runs in Docker environment with all dependencies pre-built. Build Dataframes. Bu
 
 ## Output
 In the current working directory the archive will appear, depending on platform:
-* `Dataframes-Win-x64-v141.7z` file — relocatable Dataframe library package (and all its dependencies) for 64-bit Windows.
+* `Dataframes-Win-x64.7z` file — relocatable Dataframe library package (and all its dependencies) for 64-bit Windows.
 * `Dataframes-Linux-x64.7z` file — relocatable Dataframe library package (and all its dependencies) for 64-bit Linux.
 
 ## How the input packages are built


### PR DESCRIPTION
This removes v141 suffix from Dataframes package name. It was meant to denote the C++ toolset ABI, but:
1) we do not use any other toolset that we need to differentiate between
2) library offers C API and its consumer (like luna-studio packaging scripts) should not care what was used to build it

Also, fixing the uploaded artifact name that caused package not to appear on S3.