### PR TITLE
Don't crash on developer builds on mac 

### DIFF
--- a/native_libs/src/Python/PythonInterpreter.cpp
+++ b/native_libs/src/Python/PythonInterpreter.cpp
@@ -40,7 +40,6 @@ std::optional<boost::filesystem::path> lookupLoadedLibrary(std::string_view libr
     }
 
     return std::nullopt;
-    THROW("Failed to find {}", libraryName);
 }
 #endif
 
@@ -76,7 +75,7 @@ std::optional<boost::filesystem::path> lookupLoadedLibrary(std::string libraryNa
         }
     }
 
-    THROW("Failed to find {}", libraryName);
+    return std::nullopt;
 }
 
 #endif // __APPLE__


### PR DESCRIPTION
When making code relocatable, an assumption was introduced that Dataframes will be linked with python library that looks like the one from a default local build. Using framework distribution of Python in this case causes crash. 
This PR ignores missing Python library, if there's a framework. 
Though in the long-term we should have some better way to discern between official package deployed environment and development environment.

@sylwiabr  -- please test if this change is enough to solve the issue