### PR TITLE
Bounds checking on slice operation

### DIFF
--- a/native_libs/src/Core/Common.cpp
+++ b/native_libs/src/Core/Common.cpp
@@ -3,13 +3,30 @@
 
 #include "Common.h"
 
-
-void validateIndex(const size_t size, int64_t index)
+bool isValidIndex(int64_t size, int64_t index)
 {
-    if(index < 0 || index >= (int64_t)size)
+    return index >= 0 && index < size;
+}
+
+void validateIndex(int64_t size, int64_t index)
+{
+    if(!isValidIndex(size, index))
+        THROW("wrong index={} when array's length={}", index, size);
+}
+
+void validateSlice(int64_t dataLength, int64_t sliceStart, int64_t sliceLength)
+{
+    if(sliceLength < 0)
+        THROW("slice length must be greater than zero, requested length is {}", sliceLength);
+
+    // slices of size 0 don't require valid indices, because they are empty anyway
+    if(sliceLength > 0)
     {
-        std::ostringstream out;
-        out << "wrong index " << index << " when array length is " << size;
-        throw std::out_of_range{ out.str() };
+        if(!isValidIndex(dataLength, sliceStart))
+            THROW("requested slice starting at invalid index={}, data length is {}", sliceStart, dataLength);
+
+        const auto lastIndex = sliceStart + sliceLength - 1;
+        if (lastIndex >= dataLength)
+            THROW("Slice would end at invalid index={}, length is {}", lastIndex, dataLength);
     }
 }

--- a/native_libs/src/Core/Common.h
+++ b/native_libs/src/Core/Common.h
@@ -139,7 +139,8 @@ namespace std
     }
 }
 
-void validateIndex(const size_t size, int64_t index);
+void validateIndex(int64_t size, int64_t index);
+void validateSlice(int64_t dataLength, int64_t sliceStart, int64_t sliceLength);
 
 template<typename T>
 T lerp(T v0, T v1, double t)

--- a/native_libs/src/Processing.cpp
+++ b/native_libs/src/Processing.cpp
@@ -320,6 +320,24 @@ struct InterpolatedColumnBuilder
     }
 };
 
+std::shared_ptr<arrow::Buffer> slice(std::shared_ptr<arrow::Buffer> buffer, int64_t startAt, int64_t length)
+{
+    validateSlice(buffer->size(), startAt, length);
+    return arrow::SliceBuffer(buffer, startAt, length);
+}
+
+std::shared_ptr<arrow::Column> slice(std::shared_ptr<arrow::Column> column, int64_t startAt, int64_t length)
+{
+    validateSlice(column->length(), startAt, length);
+    return column->Slice(startAt, length);
+}
+
+std::shared_ptr<arrow::Array> slice(std::shared_ptr<arrow::Array> array, int64_t startAt, int64_t length)
+{
+    validateSlice(array->length(), startAt, length);
+    return array->Slice(startAt, length);
+}
+
 std::shared_ptr<arrow::Column> interpolateNA(std::shared_ptr<arrow::Column> column)
 {
     // no missing values -- no itnerpolation needed

--- a/native_libs/src/Processing.h
+++ b/native_libs/src/Processing.h
@@ -13,6 +13,11 @@ namespace arrow
     class Table;
 }
 
+DFH_EXPORT std::shared_ptr<arrow::Buffer> slice(std::shared_ptr<arrow::Buffer> buffer, int64_t startAt, int64_t length);
+DFH_EXPORT std::shared_ptr<arrow::Array> slice(std::shared_ptr<arrow::Array> array, int64_t startAt, int64_t length);
+DFH_EXPORT std::shared_ptr<arrow::Column> slice(std::shared_ptr<arrow::Column> column, int64_t startAt, int64_t length);
+DFH_EXPORT std::shared_ptr<arrow::Table> slice(std::shared_ptr<arrow::Table> table, int64_t startAt, int64_t length);
+
 DFH_EXPORT std::shared_ptr<arrow::Column> interpolateNA(std::shared_ptr<arrow::Column> column);
 DFH_EXPORT std::shared_ptr<arrow::Table> interpolateNA(std::shared_ptr<arrow::Table> table);
 

--- a/native_libs/src/main.cpp
+++ b/native_libs/src/main.cpp
@@ -787,6 +787,14 @@ extern "C"
         LOG("@{}", (void*)column);
         return TRANSLATE_EXCEPTION(outError)
         {
+            if(count < 0)
+                THROW("Slice cannot have a negative length ({})", count);
+            if(fromIndex < 0)
+                THROW("Slice beginning at invalid index ({})", fromIndex);
+            const auto lastIndex = fromIndex + count - 1;
+            if(lastIndex >= column->length())
+                THROW("Slice enging at invalid index ({}), length is {}", lastIndex, column->length());
+
             return LifetimeManager::instance().addOwnership(column->Slice(fromIndex, count));
         };
     }

--- a/native_libs/test/Tests.cpp
+++ b/native_libs/test/Tests.cpp
@@ -1123,3 +1123,15 @@ BOOST_AUTO_TEST_CASE(Rolling, *boost::unit_test_framework::disabled())
     BOOST_CHECK_EQUAL_RANGES(get<0>(sumsPerWindowV), ts); // timestamps column should not be modified
     BOOST_CHECK_EQUAL_RANGES(get<1>(sumsPerWindowV), expectedSumsPerWindow);
 }
+
+BOOST_AUTO_TEST_CASE(SliceBoundsChecking)
+{
+    auto column = toColumn<int64_t>({ 1,2,3,4,5 });
+    BOOST_CHECK_THROW(slice(column, -1, 2), std::exception);
+    BOOST_CHECK_THROW(slice(column, 4, 2), std::exception);
+    BOOST_CHECK_NO_THROW(slice(column, 4, 1));
+    BOOST_CHECK_NO_THROW(slice(column, 4, 0));
+    BOOST_CHECK_NO_THROW(slice(column, 5, 0));
+    BOOST_CHECK_THROW(slice(column, 5, 1), std::exception);
+    BOOST_CHECK_NO_THROW(slice(column, 0, 5));
+}

--- a/src/Table.luna
+++ b/src/Table.luna
@@ -301,8 +301,7 @@ class Table:
 
     # Returns the first `count` rows
     #
-    # If the count of elements to take is greater than actual rows count, the returned table is tha same as the `self` table.
-    # For negative `count`, a table with no data will be returned.
+    # The `count` value must belong to [0, self.rowCount] range.
     #
     # > import Dataframes.Column
     # > import Dataframes.Types
@@ -317,6 +316,9 @@ class Table:
     # >     take2 = table.take 2
     # >     None
     #
+    # errors:
+    # If `count` is negative or greater than table's row count, runtime error will occur.
+    #
     # `count`: Number of rows to take.
     #
     # `return`: `Table` value with first `count` rows from `self` table.
@@ -326,8 +328,7 @@ class Table:
 
     # Drops first `count` rows.
     #
-    # If the number of elements to take is greater than actual rows number, empty table is returned.
-    # For negative `count` number the returned table is the same as `self` table. TO BE FIXED https://github.com/luna/Dataframes/issues/63
+    # The `count` value must belong to [0, self.rowCount] range.
     #
     # > import Dataframes.Column
     # > import Dataframes.Types
@@ -341,6 +342,9 @@ class Table:
     # >     table = Table.fromColumns [col1 , col2]
     # >     take2 = table.drop 2
     # >     None
+    #
+    # errors:
+    # If `count` is negative or greater than table's row count, runtime error will occur.
     #
     # `count`: Number of rows to drop.
     #


### PR DESCRIPTION
The slice operation previously didn't check the bounds, leading to invalid objects being created, leading to a possible crashes (or other unexpected results). Issue affected buffers, arrays, columns. 
The issue also affected functions implemented on slice, like `take` or `drop` (reported as #63).