### PR TITLE
Fix for #117 — vmmap needs -w argument so long paths are not shortened.

### DIFF
--- a/native_libs/src/Python/PythonInterpreter.cpp
+++ b/native_libs/src/Python/PythonInterpreter.cpp
@@ -49,10 +49,10 @@ std::optional<boost::filesystem::path> lookupLoadedLibrary(std::string_view libr
 std::optional<boost::filesystem::path> lookupLoadedLibrary(std::string libraryName)
 {
     auto pid = getpid();
-    std::string command = fmt::format("vmmap {}", pid);
+    std::string command = fmt::format("vmmap -w {}", pid);
     std::shared_ptr<FILE> pipe(popen(command.c_str(), "r"), pclose);
     if (!pipe)
-        throw std::runtime_error("popen() failed, command was: " + command);
+        THROW("popen() failed, command was: {}", command);
 
     char line[4096];
     while (!feof(pipe.get()))


### PR DESCRIPTION
The long paths in `vmmap` output are shortened by default. We require having full paths though, so we need to pass `-w` flag to allow wide output.