### PR TITLE
Fix issue with packaging ICU on macOS

### DIFF
--- a/scripts/Main.hs
+++ b/scripts/Main.hs
@@ -236,8 +236,8 @@ runTests repoDir buildArtifacts packageArtifacts = do
 main :: IO ()
 main = do
     withSystemTempDirectory "" $ \stagingDir -> do
-    -- let stagingDir = "C:\\Users\\mwurb\\AppData\\Local\\Temp\\-777f232250ff9e9c"
-    prepareEnvironment stagingDir
+        -- let stagingDir = "C:\\Users\\mwurb\\AppData\\Local\\Temp\\-777f232250ff9e9c"
+        prepareEnvironment stagingDir
         repoDir <- repoDir
         buildArtifacts <- buildProject repoDir stagingDir
         packageArtifacts <- package repoDir stagingDir buildArtifacts


### PR DESCRIPTION
This PR fixes issue where some libraries we package refer to `libicudata.63.dylib` while the shipped binary is `libicudata.63.1.dylib`. 
The more detailed explanation is in the code. Basically if the name of library matches, the dependency will be rewritten to the actual file.