### PR TITLE
Fix AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ cache:
 - C:\Users\appveyor\AppData\Local\Programs\stack
 
 build_script:
-- python -m pip install numpy
+- python -m pip install numpy==1.15.*
 - curl -sS -o stack.zip -L --insecure https://get.haskellstack.org/stable/windows-x86_64.zip
 - 7z x stack.zip -y -oC:\stack stack.exe
 - cd %APPVEYOR_BUILD_FOLDER%\scripts\


### PR DESCRIPTION
As reported in #125 AppVeyor revently fails. This is because pip started installing numpy 1.16 instead of 1.15 that our prebuilt Python package is compatible with. This change forces using compatible numpy version.