### PR TITLE
[ci, mac] Building Apache Arrow from sources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           name: Install C++ dependencies
           command: |
             brew update
-            brew install fmt cmake apache-arrow boost rapidjson howard-hinnant-date pcre pybind11 wget openssl
+            brew install fmt cmake boost rapidjson howard-hinnant-date pcre pybind11 wget openssl
       - run:
           name: Build Python
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,20 @@ jobs:
             cd .. &&\
             rm -rf Python-3.7.0.tar.xz Python-3.7.0
       - run:
+          name: Install Apache Arrow library
+          command: |
+            cd ~
+            wget https://github.com/apache/arrow/archive/apache-arrow-0.12.0.zip
+            unzip apache-arrow-0.12.0.zip
+            cd arrow-apache-arrow-0.12.0
+            mkdir build
+            cd build
+            cmake ../cpp -DCMAKE_BUILD_TYPE=Release
+            make -j 4
+            make install
+            cd ../../
+            rm -rf arrow-apache-arrow-0.12.0 apache-arrow-0.12.0.zip
+      - run:
           name: Install XLNT library
           command: |
             cd ~


### PR DESCRIPTION
We cannot use brew anymore for this library, as the `apache-arrow` formula was removed: https://github.com/Homebrew/homebrew-core/commit/6cd7f61d2d07d5fd9f8747ea0f620169cc8a2434