### PR TITLE
Fix AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.0.{build}
-image: Previous Visual Studio 2017
+image: Visual Studio 2017
 environment:
   PATH: C:\Python37-x64;C:\stack;%PATH%
   PythonDir: C:\Python37-x64


### PR DESCRIPTION
Visual 15.9 has a regression. Because AppVeyor forces us to use that particular build, we need to have this workaround. To be removed when we upgrade to 16.0 or when forcing 15.8 toolset is possible.

See https://developercommunity.visualstudio.com/content/problem/395993/159-regression-error-on-valid-c-code-constexpr-if.html