### PR TITLE
Ungroup splitting

### DIFF
--- a/data/ungroupable.csv
+++ b/data/ungroupable.csv
@@ -1,0 +1,5 @@
+name,tags
+First,good bad
+,so-so
+Second,
+Last,good

--- a/native_libs/src/Core/ArrowUtilities.cpp
+++ b/native_libs/src/Core/ArrowUtilities.cpp
@@ -132,6 +132,25 @@ std::shared_ptr<arrow::Table> tableFromColumns(const std::vector<std::shared_ptr
     return arrow::Table::Make(schema, tableColumns);
 }
 
+std::shared_ptr<arrow::Table> replaceColumn(const arrow::Table &table, const arrow::Column &columnToBeReplaced, std::shared_ptr<arrow::Column> replaceWith)
+{
+    std::vector<std::shared_ptr<arrow::Column>> ret;
+    for(auto &&column : getColumns(table))
+    {
+        if(column.get() != &columnToBeReplaced)
+            ret.push_back(column);
+        else
+            ret.push_back(replaceWith);
+    }
+    return tableFromColumns(ret);
+}
+
+std::shared_ptr<arrow::Table> replaceColumn(const arrow::Table &table, int index, std::shared_ptr<arrow::Column> column)
+{
+    validateIndex(table.num_columns(), index);
+    return replaceColumn(table, *table.column(index), std::move(column));
+}
+
 DynamicJustVector toJustVector(const arrow::ChunkedArray &chunkedArray)
 {
     return visitType(*chunkedArray.type(), [&] (auto id)  -> DynamicJustVector

--- a/native_libs/src/Processing.cpp
+++ b/native_libs/src/Processing.cpp
@@ -794,7 +794,7 @@ std::shared_ptr<arrow::Column> concat(const arrow::Column &listColumn)
     }
 
     auto cha = std::make_shared<arrow::ChunkedArray>(retArrays, type->value_type());
-    return std::make_shared<arrow::Column>(listColumn.name(), cha);
+    return toColumn(cha, listColumn.name());
 }
 
 std::shared_ptr<arrow::Table> ungroup(const arrow::Table &table, std::shared_ptr<arrow::Column> listColumn)

--- a/native_libs/src/Processing.cpp
+++ b/native_libs/src/Processing.cpp
@@ -717,7 +717,7 @@ std::shared_ptr<arrow::Column> splitOn(const arrow::Column &column, std::string_
             }
             else
             {
-                stringBuilder->Append(text.substr(position));
+                append(*stringBuilder, text.substr(position));
                 break;
             }
         }

--- a/native_libs/src/Processing.cpp
+++ b/native_libs/src/Processing.cpp
@@ -712,7 +712,7 @@ std::shared_ptr<arrow::Column> splitOn(const arrow::Column &column, std::string_
             if(const auto nextSeparator = text.find_first_of(separator, position);
                 nextSeparator != std::string::npos)
             {
-                stringBuilder->Append(text.substr(position, nextSeparator - position));
+                append(*stringBuilder, text.substr(position, nextSeparator - position));
                 position = nextSeparator + 1;
             }
             else

--- a/native_libs/src/Processing.h
+++ b/native_libs/src/Processing.h
@@ -36,3 +36,9 @@ DFH_EXPORT std::shared_ptr<arrow::Column> shift(std::shared_ptr<arrow::Column> c
 
 DFH_EXPORT DynamicField adjustTypeForFilling(DynamicField valueGivenByUser, const arrow::DataType &type);
 DFH_EXPORT std::shared_ptr<arrow::Table> groupBy(std::shared_ptr<arrow::Table> table, std::shared_ptr<arrow::Column> keyColumn);
+
+DFH_EXPORT std::shared_ptr<arrow::Column> splitOn(const arrow::Column &column, std::string_view separator); // Column String -> Column [String]
+DFH_EXPORT std::shared_ptr<arrow::Column> ungroup(const arrow::Column &data, const arrow::Column &listColumn); // (Column t1, Column [t2]) -> Column t1
+DFH_EXPORT std::shared_ptr<arrow::Column> concat(const arrow::Column &listColumn); // Column [a] -> Column a
+DFH_EXPORT std::shared_ptr<arrow::Table> ungroup(const arrow::Table &table, std::shared_ptr<arrow::Column> listColumn);
+DFH_EXPORT std::shared_ptr<arrow::Table> ungroupSplittingOn(const arrow::Table &table, const arrow::Column &stringColumn, std::string_view separator);

--- a/native_libs/src/main.cpp
+++ b/native_libs/src/main.cpp
@@ -1291,6 +1291,16 @@ extern "C"
             return LifetimeManager::instance().addOwnership(ret);
         };
     }
+
+    DFH_EXPORT arrow::Table *tableUngroupSplittingOn(arrow::Table *table, arrow::Column *stringColumn, const char *separator, const char **outError) noexcept
+    {
+        LOG("@{}, column={}, separator={}", (void*)table, (void*)stringColumn, separator);
+        return TRANSLATE_EXCEPTION(outError)
+        {
+            auto ret = ungroupSplittingOn(*table, *stringColumn, separator);
+            return LifetimeManager::instance().addOwnership(ret);
+        };
+    }
 }
 
 arrow::Table *readTableFromCSVFileContentsHelper(std::string data, const char **columnNames, int32_t columnNamesPolicy, int8_t *columnTypes, int8_t *columnIsNullableTypes, int32_t columnTypeInfoCount)

--- a/native_libs/test/Tests.cpp
+++ b/native_libs/test/Tests.cpp
@@ -1213,3 +1213,23 @@ BOOST_AUTO_TEST_CASE(RelaxedAggregationRules)
     }
 }
 
+BOOST_AUTO_TEST_CASE(UngroupSimple)
+{
+    const auto table = readTableFromFile("data/ungroupable.csv");
+    //uglyPrint(*table);
+    const auto tableUngrouped = ungroupSplittingOn(*table, *table->column(1), " ");
+    //uglyPrint(*table2);
+
+    const std::vector<std::optional<std::string>> expectedUngroupedNames
+    {
+        "First", "First", std::nullopt, "Last"
+    };
+    const std::vector<std::optional<std::string>> expectedUngroupedTags
+    {
+        "good", "bad", "so-so", "good"
+    };
+
+    const auto [ungroupedNames, ungroupedTags] = toVectors<std::optional<std::string>, std::optional<std::string>>(*tableUngrouped);
+    BOOST_CHECK_EQUAL_RANGES(ungroupedNames, expectedUngroupedNames);
+    BOOST_CHECK_EQUAL_RANGES(ungroupedTags, expectedUngroupedTags);
+}

--- a/src/Internal/CWrappers.luna
+++ b/src/Internal/CWrappers.luna
@@ -386,6 +386,12 @@ class TableWrapper:
                         callHandlingError "tableRollingTimeInterval" (Pointer None) [keyColumn.ptr.toCArg, CInt64.fromInt intervalNs . toCArg, CInt32.fromInt aggregation.length . toCArg, aggregatedColumnsC.toCArg, aggregateFunctionCountsC.toCArg, arrayOfArraysWithIds.toCArg]
         wrapReleasableResouce TableWrapper ptr
 
+    # ungroupSplittingOn :: ColumnWrapper -> String -> TableWrapper
+    def ungroupSplittingOn stringColumn separator:
+        ptr = CString.with separator separatorC:
+            callHandlingError "tableUngroupSplittingOn" (Pointer None) [self.ptr.toCArg, stringColumn.ptr.toCArg, separatorC.toCArg]
+        wrapReleasableResouce TableWrapper ptr
+
     # write :: Filepath -> ()
     def write path:
         CString.with path pathC:

--- a/src/Main.luna
+++ b/src/Main.luna
@@ -1,17 +1,12 @@
 import Std.Base
 import Std.Foreign.C.Value
 
-import Dataframes.Column
+import Dataframes.Internal.Utils
+import Dataframes.Array
 import Dataframes.Types
-import Dataframes.Table
+import Dataframes.Internal.Test.Test
 
-def renameAt self index name:
-    col = Table.columnAt index
-    col2 = col.rename name
-    
 
 def main:
-    t = Table.read "C:/Users/mwu/Downloads/games.csv"
-    t2 = t.ungroupSplittingOn "tag" " "
-    print t
-    print t2
+    setHelperVerbosity False
+    benchmark "running tests" TestArrayBuilder.run

--- a/src/Main.luna
+++ b/src/Main.luna
@@ -1,12 +1,17 @@
 import Std.Base
 import Std.Foreign.C.Value
 
-import Dataframes.Internal.Utils
-import Dataframes.Array
+import Dataframes.Column
 import Dataframes.Types
-import Dataframes.Internal.Test.Test
+import Dataframes.Table
 
+def renameAt self index name:
+    col = Table.columnAt index
+    col2 = col.rename name
+    
 
 def main:
-    setHelperVerbosity False
-    benchmark "running tests" TestArrayBuilder.run
+    t = Table.read "C:/Users/mwu/Downloads/games.csv"
+    t2 = t.ungroupSplittingOn "tag" " "
+    print t
+    print t2

--- a/src/Table.luna
+++ b/src/Table.luna
@@ -854,6 +854,11 @@ class Table:
     def rollingInterval keyColumnName interval aggregateColumnName aggregateFunction:
         self.rollingIntervalMultiple keyColumnName interval [(aggregateColumnName,[aggregateFunction])]
 
+    # ungroupSplittingOn :: Text -> Text -> Table
+    def ungroupSplittingOn stringColumnName separator:
+        stringColumnWrapper = self.column stringColumnName . ptr
+        self.fromWrapper $ self.ptr.ungroupSplittingOn stringColumnWrapper separator
+
     # shift :: Text -> Int -> Table
     def shift columnName periods:
         columnToShift = self.column columnName


### PR DESCRIPTION
An utility needed for upcoming demo. Function `Table.ungroupSplittingOn` allows ungrouping rows by splitting strings in a given column.

E.g.
```
import Std.Base
import Std.Foreign.C.Value

import Dataframes.Column
import Dataframes.Types
import Dataframes.Table

def renameAt self index name:
    col = Table.columnAt index
    col2 = col.rename name
    

def main:
    t = Table.read "C:/Users/mwu/Downloads/games.csv"
    t2 = t.ungroupSplittingOn "tag" " "
    print t
    print t2
```



Basically, the purpose is to transform table like:

|col1|col2|
|---|------|
| a |  foo bar |
| b | foo baz  |
| c | fff      |

into:

|col1|col2|
|---|------|
| a |  foo |
| a | bar  |
| b | foo  |
| b | baz  |
| c | fff  |


It allows ungrouping rows by splitting over any string separator in given string column.

In a longer term this use case should be addressed in a more general way by using Arrow's lists, for now this is reasonable addition.