### PR TITLE
[packaging] Set binaries to be writeable during patching. 

### DIFF
--- a/scripts/Main.hs
+++ b/scripts/Main.hs
@@ -188,8 +188,8 @@ package repoDir stagingDir buildArtifacts = do
             return ()
         Linux -> do
             dependencies <- Linux.dependenciesToPackage builtDlls
-            mapM (Patchelf.installDependencyTo packageBinariesDir) dependencies
-            mapM (Patchelf.installBinary packageBinariesDir packageBinariesDir) builtDlls
+            mapM (Linux.installDependencyTo packageBinariesDir) dependencies
+            mapM (Linux.installBinary packageBinariesDir packageBinariesDir) builtDlls
 
             -- Copy Python installation to the package and remove some parts that are heavy and not needed.
             pythonPrefix <- pythonPrefix

--- a/scripts/Platform/Linux.hs
+++ b/scripts/Platform/Linux.hs
@@ -1,9 +1,14 @@
 module Platform.Linux where
 
+import Control.Exception (bracket)
 import Data.List
 import System.FilePath
+import System.PosixCompat.Files (fileMode, getFileStatus, ownerWriteMode, setFileMode, unionFileModes)
 
 import qualified Program.Ldd as Ldd
+import qualified Program.Patchelf as Patchelf
+import Utils (copyToDir)
+
 -- List of filenames of libraries that should not be distributed along with
 -- our package but rather should be assumed to be present on end-user's machine
 --
@@ -31,3 +36,28 @@ canBeDistributed libraryPath = notElem (dropExtensions $ takeFileName libraryPat
 -- out should be assumed to be present at end-user's machine.
 dependenciesToPackage :: [FilePath] -> IO [FilePath]
 dependenciesToPackage binaries = filter canBeDistributed <$> Ldd.dependenciesOfBinaries binaries
+
+-- Executes action while temporarily changing file mode to make it writable to owner.
+-- Restores file mode before returning.
+-- Will fail if the file is not owned.
+withWritableFile :: FilePath -> IO () -> IO ()
+withWritableFile path action = bracket makeWritable restoreMode (const action) where
+    makeWritable = do
+        oldStatus <- getFileStatus path
+        setFileMode path $ unionFileModes (fileMode oldStatus) ownerWriteMode
+        return oldStatus
+    restoreMode oldStatus = setFileMode path (fileMode oldStatus)
+    
+
+-- Copies the binary to the given directory and sets rpath relative path to another directory.
+-- (the dependencies directory will be treated as relative to the output directory)
+installBinary :: FilePath -> FilePath -> FilePath -> IO ()
+installBinary outputDirectory dependenciesDirectory sourcePath = do
+    newBinaryPath <- copyToDir outputDirectory sourcePath
+    withWritableFile newBinaryPath $ 
+        Patchelf.setRelativeRpath newBinaryPath [dependenciesDirectory, outputDirectory]
+
+-- Installs binary to the folder and sets this folder as rpath.
+-- Typically used with dependencies (when install-to directory and dependencies directory are same)
+installDependencyTo :: FilePath -> FilePath -> IO ()
+installDependencyTo targetDirectory sourcePath = installBinary targetDirectory targetDirectory sourcePath

--- a/scripts/Program/Patchelf.hs
+++ b/scripts/Program/Patchelf.hs
@@ -38,16 +38,3 @@ setRpath binaryPath rpath = do
 removeRpath :: FilePath -> IO ()
 removeRpath binaryPath = call @Patchelf ["--remove-rpath", binaryPath]
 
---------------------------------------------------------------------------------------
-
--- Copies the binary to the given directory and sets rpath relative path to another directory.
--- (the dependencies directory will be treated as relative to the output directory)
-installBinary :: FilePath -> FilePath -> FilePath -> IO ()
-installBinary outputDirectory dependenciesDirectory sourcePath = do
-    newBinaryPath <- copyToDir outputDirectory sourcePath
-    setRelativeRpath newBinaryPath [dependenciesDirectory, outputDirectory]
-
--- Installs binary to the folder and sets this folder as rpath.
--- Typically used with dependencies (when install-to directory and dependencies directory are same)
-installDependencyTo :: FilePath -> FilePath -> IO ()
-installDependencyTo targetDirectory sourcePath = installBinary targetDirectory targetDirectory sourcePath

--- a/scripts/package.yaml
+++ b/scripts/package.yaml
@@ -47,3 +47,4 @@ dependencies:
 - process
 - temporary
 - text
+- unix-compat


### PR DESCRIPTION
This PR:
1. Moved `installBinary` and `installDependencyTo` from `Program.Patchelf` module to `Platform.Linux` module. Program modules are intended to contain simple wrappers over program commands. More complex actions involving calling multiple programs do not belong there.

2. `installBinary` temporarily changes patched binary file permissions to make it writeable. Even though this is a copy that we own it might be non-writable — this blocks Azure-based CI, as Docker containers are used with non-root user there (and installed libraries are read-only).