### PR TITLE
Update CI config to prevent double runs in PRs

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -4,6 +4,12 @@ trigger:
   branches:
     include:
     - "*"
+  paths:
+    exclude:
+    - README.md
+    - LICENSE
+
+pr: none
 
 variables:
   Dataframes.Repo.Path: $(Build.SourcesDirectory) # this one is required by the build script


### PR DESCRIPTION
Does what it says on the tin. This is the same fix that we applied to Luna in https://github.com/luna/luna/pull/395 to prevent CI from running both percommit and in a PR context. 