### PR TITLE
Fix for Column.toList to properly compile on recent typechecker. See #61

### DIFF
--- a/src/Column.luna
+++ b/src/Column.luna
@@ -4,6 +4,7 @@ import Dataframes.Field
 import Dataframes.Schema
 import Dataframes.Table
 import Dataframes.Types
+import Dataframes.Value
 
 import Dataframes.Internal.CWrappers
 import Dataframes.Internal.Utils
@@ -74,16 +75,17 @@ class Column:
             ColumnMaybeText      tc: tc.ptr
             ColumnTimestamp      tc: tc.ptr
             ColumnMaybeTimestamp tc: tc.ptr
+
     def toList:
         case self of
-            ColumnInt            tc: tc.toList
-            ColumnMaybeInt       tc: tc.toList
-            ColumnReal           tc: tc.toList
-            ColumnMaybeReal      tc: tc.toList
-            ColumnText           tc: tc.toList
-            ColumnMaybeText      tc: tc.toList
-            ColumnTimestamp      tc: tc.toList
-            ColumnMaybeTimestamp tc: tc.toList
+            ColumnInt            tc: tc.toList.each ValueInt
+            ColumnMaybeInt       tc: tc.toList.each ValueMaybeInt
+            ColumnReal           tc: tc.toList.each ValueReal
+            ColumnMaybeReal      tc: tc.toList.each ValueMaybeReal
+            ColumnText           tc: tc.toList.each ValueText
+            ColumnMaybeText      tc: tc.toList.each ValueMaybeText
+            ColumnTimestamp      tc: tc.toList.each ValueTimestamp
+            ColumnMaybeTimestamp tc: tc.toList.each ValueMaybeTimestamp
 
     def slice fromIndex length:
         case self of

--- a/src/Value.luna
+++ b/src/Value.luna
@@ -1,0 +1,68 @@
+import Dataframes.Types
+
+class Value:
+    Value
+    ValueInt            (Int)
+    ValueMaybeInt       (Maybe Int)
+    ValueReal           (Real)
+    ValueMaybeReal      (Maybe Real)
+    ValueText           (Text)
+    ValueMaybeText      (Maybe Text)
+    ValueTimestamp      (Time)
+    ValueMaybeTimestamp (Maybe Time)
+
+    # Returns the stored Int value. If the stored value is a Real value, it
+    # will be rounded down.
+    def toInt:
+        case self of
+            ValueInt            val: val
+            ValueReal           val: val.floor
+            _                      : 
+                throw $ "toInt: value not convertible to Int: " + self.toText
+
+    # Returns the stored Real value. If the stored value is a Int value, it
+    # will be converted.
+    def toReal:
+        case self of
+            ValueInt            val: val.toReal
+            ValueReal           val: val
+            _                      : 
+                throw "toReal: value not convertible to Real: " + self.toText
+
+    # Returns the stored Text value. If the stored value is of another type, it
+    # will be pretty-printed.
+    def toText:
+        case self of
+            ValueInt            val: val.toText
+            ValueMaybeInt       val: val.toText
+            ValueReal           val: val.toText
+            ValueMaybeReal      val: val.toText
+            ValueText           val: val.toText
+            ValueMaybeText      val: val.toText
+            ValueTimestamp      val: val.toText
+            ValueMaybeTimestamp val: val.toText
+
+    # Converts a value to JSON.
+    def toJSON:
+        case self of
+            ValueInt            val: val.toJSON
+            ValueMaybeInt       val: val.toJSON
+            ValueReal           val: val.toJSON
+            ValueMaybeReal      val: val.toJSON
+            ValueText           val: val.toJSON
+            ValueMaybeText      val: val.toJSON
+            ValueTimestamp      val: val.toJSON
+            ValueMaybeTimestamp val: val.toJSON
+
+    # Displays a short representation of `Value` object for use in interactive 
+    # mode.
+    def shortRep:
+        case self of
+            ValueInt            val: val.shortRep
+            ValueMaybeInt       val: val.shortRep
+            ValueReal           val: val.shortRep
+            ValueMaybeReal      val: val.shortRep
+            ValueText           val: val.shortRep
+            ValueMaybeText      val: val.shortRep
+            ValueTimestamp      val: val.shortRep
+            ValueMaybeTimestamp val: val.shortRep


### PR DESCRIPTION
### Pull Request Description
Due to recent fixes in the typechecker, Column.toList method stopped to compile. See #61. 

This PR addresses the issue by introducing a new class `Dataframes.Value` that is meant to be a type-erased wrapper for any supported cell value. With such type, Column.toList can just return `[Value]` and properly typecheck.

### Important Notes
Some `Column` methods that depended on `Column.toList` changed their return type to `Value`:
* minValue
* maxValue
* meanValue
* medianValue
* stdValue
* varValue
* sumValue

I don't think that involves any breakage.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code has been tested where possible.

