### PR TITLE
Fix PythonInterpreter.cpp for new version of date

### DIFF
--- a/native_libs/src/Python/PythonInterpreter.cpp
+++ b/native_libs/src/Python/PythonInterpreter.cpp
@@ -220,7 +220,7 @@ pybind11::object PythonInterpreter::toPyDateTime(Timestamp timestamp) const
     using namespace date;
     auto daypoint = floor<days>(timestamp);
     auto ymd = year_month_day(daypoint);   // calendar date
-    time_of_day tod = make_time(timestamp - daypoint); // Yields time_of_day type
+    auto tod = make_time(timestamp - daypoint); // Yields time_of_day type
 
                                                // Obtain individual components as integers
     auto y = (int)ymd.year();


### PR DESCRIPTION
Since `time_of_day` is no longer a class in the new version of `date`, this line would break when compiling
Mentioned in #152 