### PR TITLE
Better error message on failed Table.read

### DIFF
--- a/native_libs/src/Core/Common.h
+++ b/native_libs/src/Core/Common.h
@@ -169,13 +169,13 @@ std::vector<T> iotaVector(size_t N, T from = T{})
 
 #define THROW_OBJ(EXC_TO_THROW) do {                                                     \
     std::cerr << __FILE__ << " " << __LINE__ << " " << EXC_TO_THROW.what() << std::endl; \
-	throw EXC_TO_THROW;                                                                  \
+    throw EXC_TO_THROW;                                                                  \
 } while(0)
 
-#define THROW(message, ...)  do {                                         \
-	auto msg_ =  fmt::format(message, ##__VA_ARGS__);                     \
-	std::runtime_error e_to_throw{fmt::format(message, ##__VA_ARGS__)};   \
-    THROW_OBJ(e_to_throw);                                                \
+#define THROW(message, ...)  do {                                       \
+    auto msg_ =  fmt::format(message, ##__VA_ARGS__);                   \
+    std::runtime_error e_to_throw{fmt::format(message, ##__VA_ARGS__)}; \
+    THROW_OBJ(e_to_throw);                                              \
 } while(0)
 
 namespace detail

--- a/native_libs/src/Core/Common.h
+++ b/native_libs/src/Core/Common.h
@@ -167,12 +167,15 @@ std::vector<T> iotaVector(size_t N, T from = T{})
     return ret;
 }
 
+#define THROW_OBJ(EXC_TO_THROW) do {                                                     \
+    std::cerr << __FILE__ << " " << __LINE__ << " " << EXC_TO_THROW.what() << std::endl; \
+	throw EXC_TO_THROW;                                                                  \
+} while(0)
 
 #define THROW(message, ...)  do {                                         \
 	auto msg_ =  fmt::format(message, ##__VA_ARGS__);                     \
-	std::cerr << __FILE__ << " " << __LINE__ << " " << msg_ << std::endl; \
 	std::runtime_error e_to_throw{fmt::format(message, ##__VA_ARGS__)};   \
-	throw e_to_throw;                                                     \
+    THROW_OBJ(e_to_throw);                                                \
 } while(0)
 
 namespace detail

--- a/native_libs/src/IO/IO.cpp
+++ b/native_libs/src/IO/IO.cpp
@@ -131,17 +131,10 @@ std::ifstream openFileToRead(std::string_view filepath)
     std::ifstream in{ (std::string)filepath, std::ios::binary };
 #endif
 
-    try
+    if(!in)
     {
-        const auto initialMask = in.exceptions();
-        // temporarily set mask to force an exception if stream is broken
-        in.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-        in.exceptions(initialMask);
-    }
-    catch(std::ifstream::failure &)
-    {
-        // Do not use `std::system_error::code` - libstdc++ does not implement it.
-        // Even on platforms where it works, the error message doesn't really helps (msvc 19.1)
+        // Do not bother catching std::ifstream::failure and checking its supposedly inherited `std::system_error::code`.
+        // libstdc++ does not implement it and even on platforms where it works, the error message is not helpful at all.
         // If we really want to give proper diagnostics for filesystem errors, we would need to get platform-specific.
         CannotOpenToRead cannotRead{ filepath };
         THROW_OBJ(cannotRead);

--- a/native_libs/src/IO/IO.h
+++ b/native_libs/src/IO/IO.h
@@ -19,6 +19,16 @@ namespace arrow
     class DataType;
 }
 
+struct CannotReadFileException : std::runtime_error
+{
+    CannotReadFileException(std::string_view path, std::string_view message)
+        : std::runtime_error(fmt::format("Cannot read file {}: {}", path, message))
+    {}
+    CannotReadFileException(std::string_view path, std::exception &e)
+        : CannotReadFileException(path, e.what())
+    {}
+};
+
 struct TakeFirstRowAsHeaders {};
 struct GenerateColumnNames {};
 

--- a/native_libs/src/IO/IO.h
+++ b/native_libs/src/IO/IO.h
@@ -24,7 +24,7 @@ struct CannotReadFileException : std::runtime_error
     CannotReadFileException(std::string_view path, std::string_view message)
         : std::runtime_error(fmt::format("Cannot read file {}: {}", path, message))
     {}
-    CannotReadFileException(std::string_view path, std::exception &e)
+    CannotReadFileException(std::string_view path, const std::exception &e)
         : CannotReadFileException(path, e.what())
     {}
 };

--- a/native_libs/src/IO/IO.h
+++ b/native_libs/src/IO/IO.h
@@ -19,13 +19,10 @@ namespace arrow
     class DataType;
 }
 
-struct CannotReadFileException : std::runtime_error
+struct CannotOpenToRead : std::runtime_error
 {
-    CannotReadFileException(std::string_view path, std::string_view message)
-        : std::runtime_error(fmt::format("Cannot read file {}: {}", path, message))
-    {}
-    CannotReadFileException(std::string_view path, const std::exception &e)
-        : CannotReadFileException(path, e.what())
+    CannotOpenToRead(std::string_view path)
+        : std::runtime_error(fmt::format("Cannot open file to read: {}", path))
     {}
 };
 

--- a/native_libs/test/Tests.cpp
+++ b/native_libs/test/Tests.cpp
@@ -1162,6 +1162,12 @@ BOOST_AUTO_TEST_CASE(SliceBoundsChecking)
     BOOST_CHECK_NO_THROW(slice(column, 0, 5));
 }
 
+BOOST_AUTO_TEST_CASE(ReadMissingCsvFile)
+{
+    auto pathUnlikelyToExist = "data/gbhfudbfiugbiu.csv";
+    BOOST_CHECK_THROW(readTableFromFile(pathUnlikelyToExist), CannotReadFileException); //bogus name
+}
+
 BOOST_AUTO_TEST_CASE(ReadCsvFileWithBOM)
 {
     const auto t = FormatCSV{}.read("data/fileWithBOM.csv");

--- a/native_libs/test/Tests.cpp
+++ b/native_libs/test/Tests.cpp
@@ -1164,8 +1164,8 @@ BOOST_AUTO_TEST_CASE(SliceBoundsChecking)
 
 BOOST_AUTO_TEST_CASE(ReadMissingCsvFile)
 {
-    auto pathUnlikelyToExist = "data/gbhfudbfiugbiu.csv";
-    BOOST_CHECK_THROW(readTableFromFile(pathUnlikelyToExist), CannotReadFileException); //bogus name
+    const auto pathUnlikelyToExist = "data/gbhfudbfiugbiu.csv";
+    BOOST_CHECK_THROW(readTableFromFile(pathUnlikelyToExist), CannotReadFileException);
 }
 
 BOOST_AUTO_TEST_CASE(ReadCsvFileWithBOM)

--- a/native_libs/test/Tests.cpp
+++ b/native_libs/test/Tests.cpp
@@ -1165,7 +1165,7 @@ BOOST_AUTO_TEST_CASE(SliceBoundsChecking)
 BOOST_AUTO_TEST_CASE(ReadMissingCsvFile)
 {
     const auto pathUnlikelyToExist = "data/gbhfudbfiugbiu.csv";
-    BOOST_CHECK_THROW(readTableFromFile(pathUnlikelyToExist), CannotReadFileException);
+    BOOST_CHECK_THROW(readTableFromFile(pathUnlikelyToExist), CannotOpenToRead);
 }
 
 BOOST_AUTO_TEST_CASE(ReadCsvFileWithBOM)


### PR DESCRIPTION
### Pull Request Description
It has been reported on Discord that our current error message on `Table.read` not being able top open/read file is not helpful. Reason is two-fold:
1) the error pretty printing call was missing an argument, so we got error-formetting-error instead of actual error;
2) the actual error wouldn't be helpful anyway -- we ignored the actual error with reading file (that can be caused by wrong permission settings or wrong path), because we expect failure possibility when trying to match proper parser for given file.

Now not being able to read file is a special class of errors that stop the parser-matching routine and allow to give proper diagnostics to the user.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs. 
-->

### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] The code has been tested where possible.

